### PR TITLE
Update integration with external mujoco library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+build/
 Lingo.lock
 bin
 src-gen

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ tar xvf mujoco-*
 sudo mv mujoco-3.2.6 /opt/mujoco
 ```
 
+Alternatively, Mujoco can be built from source as explained under the section for MacOS below.
 
 ### macOS
 1. Install GLFW, a graphics library used by MuJoCo

--- a/README.md
+++ b/README.md
@@ -6,27 +6,45 @@ The derived reactors customize this base class for particular MuJoCo model files
 
 ## Prerequisites
 
-MuJoCo depends on [GLFW](https://www.glfw.org), a graphics library that you must install.  On macOS:
+
+### Linux (Ubuntu)
+
+1. Install GLFW, a graphics library used by MuJoCo
+
+```sh
+apt install libglfw3-dev
+```
+
+2. Download pre-built Mujoco v3.2.6 binaries from [here](https://github.com/google-deepmind/mujoco/releases/tag/3.2.6).
+```sh
+wget wget https://github.com/google-deepmind/mujoco/releases/download/3.2.6/mujoco-3.2.6-linux-x86_64.tar.gz
+```
+
+3. Install to `/opt` 
+```sh
+sudo mkdir -p /opt/mujoco-3.2.6-linux-x86_64/
+tar xvf mujoco-3.2.6-linux-x86_64.tar.gz --directory /opt/mujoco-3.2.6-linux-x86_64/
+```
+### macOS
+
+MuJoCo depends on [GLFW](https://www.glfw.org), a graphics library that you must install. On macOS:
 
 ```sh
 brew install glfw
 ```
 
-MuJoCo itself seems to be best installed from source.  The following worked for me on macOS:
-
+2. Download the Mujoco v3.2.6 DMG disk image from [here](https://github.com/google-deepmind/mujoco/releases/tag/3.2.6).
 ```sh
-git clone git@github.com:google-deepmind/mujoco.git
-cd mujoco
-mkdir build
-cd build
-cmake .. -DCMAKE_INSTALL_PREFIX=/usr/local
-cmake --build .
-sudo cmake --install .
+wget wget https://github.com/google-deepmind/mujoco/releases/download/3.2.6/mujoco-3.2.6-macos-universal2.dmg
 ```
 
-The `sudo` on the last line is required to install it in `/usr/local`, which is what I did.
+3. Install to `/Application` by double-clicking the DMG and dragging MuJoCo.app into `/Applications` 
 
-The [mujoco.cmake](src/include/mujoco.cmake) file will need to be changed if you change either of the above install locations.
+
+### All platforms
+
+If another version of mujoco is installed, or if it is placed in a different location
+the [mujoco.cmake](src/include/mujoco.cmake) must be updated accordingly.
 
 ## Demos
 

--- a/README.md
+++ b/README.md
@@ -8,21 +8,28 @@ The derived reactors customize this base class for particular MuJoCo model files
 
 ### Linux (Ubuntu)
 
-Install GLFW, a graphics library used by MuJoCo
+1. Install GLFW, a graphics library used by MuJoCo
 
 ```sh
 apt install libglfw3-dev
 ```
 
+2. Download a prebuilt version of Mujoco v3.2.6 and install it to `/opt/mujoco`. The following works for x86, for aarch64, change the download path accordingly (https://github.com/google-deepmind/mujoco/releases/tag/3.2.6)
+```sh
+wget https://github.com/google-deepmind/mujoco/releases/download/3.2.6/mujoco-3.2.6-linux-x86_64.tar.gz
+tar xvf mujoco-*
+sudo mv mujoco-3.2.6 /opt/mujoco
+```
+
+
 ### macOS
-Install GLFW, a graphics library used by MuJoCo
+1. Install GLFW, a graphics library used by MuJoCo
 
 ```sh
 brew install glfw
 ```
 
-### All platforms
-Build Mujoco v3.2.6 from source and install to `/opt/mujoco`
+2. Build Mujoco v3.2.6 from source and install to `/opt/mujoco`
 
 ```sh
 git clone git@github.com:google-deepmind/mujoco.git -b 3.2.6
@@ -34,6 +41,8 @@ cmake --build .
 sudo cmake --install .
 
 ```
+
+### All platforms
 
 If mujoco is installed to a different location the
 [mujoco.cmake](src/include/mujoco.cmake) must be updated accordingly.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ brew install glfw
 
 2. Download the Mujoco v3.2.6 DMG disk image from [here](https://github.com/google-deepmind/mujoco/releases/tag/3.2.6).
 ```sh
-wget wget https://github.com/google-deepmind/mujoco/releases/download/3.2.6/mujoco-3.2.6-macos-universal2.dmg
+wget https://github.com/google-deepmind/mujoco/releases/download/3.2.6/mujoco-3.2.6-macos-universal2.dmg
 ```
 
 3. Install to `/Application` by double-clicking the DMG and dragging MuJoCo.app into `/Applications` 

--- a/README.md
+++ b/README.md
@@ -6,45 +6,37 @@ The derived reactors customize this base class for particular MuJoCo model files
 
 ## Prerequisites
 
-
 ### Linux (Ubuntu)
 
-1. Install GLFW, a graphics library used by MuJoCo
+Install GLFW, a graphics library used by MuJoCo
 
 ```sh
 apt install libglfw3-dev
 ```
 
-2. Download pre-built Mujoco v3.2.6 binaries from [here](https://github.com/google-deepmind/mujoco/releases/tag/3.2.6).
-```sh
-wget wget https://github.com/google-deepmind/mujoco/releases/download/3.2.6/mujoco-3.2.6-linux-x86_64.tar.gz
-```
-
-3. Install to `/opt` 
-```sh
-sudo mkdir -p /opt/mujoco-3.2.6-linux-x86_64/
-tar xvf mujoco-3.2.6-linux-x86_64.tar.gz --directory /opt/mujoco-3.2.6-linux-x86_64/
-```
 ### macOS
-
-MuJoCo depends on [GLFW](https://www.glfw.org), a graphics library that you must install. On macOS:
+Install GLFW, a graphics library used by MuJoCo
 
 ```sh
 brew install glfw
 ```
 
-2. Download the Mujoco v3.2.6 DMG disk image from [here](https://github.com/google-deepmind/mujoco/releases/tag/3.2.6).
+### All platforms
+Build Mujoco v3.2.6 from source and install to `/opt/mujoco`
+
 ```sh
-wget https://github.com/google-deepmind/mujoco/releases/download/3.2.6/mujoco-3.2.6-macos-universal2.dmg
+git clone git@github.com:google-deepmind/mujoco.git -b 3.2.6
+cd mujoco
+mkdir build
+cd build
+cmake .. -DCMAKE_INSTALL_PREFIX=/opt/mujoco
+cmake --build .
+sudo cmake --install .
+
 ```
 
-3. Install to `/Application` by double-clicking the DMG and dragging MuJoCo.app into `/Applications` 
-
-
-### All platforms
-
-If another version of mujoco is installed, or if it is placed in a different location
-the [mujoco.cmake](src/include/mujoco.cmake) must be updated accordingly.
+If mujoco is installed to a different location the
+[mujoco.cmake](src/include/mujoco.cmake) must be updated accordingly.
 
 ## Demos
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ brew install glfw
 2. Build Mujoco v3.2.6 from source and install to `/opt/mujoco`
 
 ```sh
-git clone git@github.com:google-deepmind/mujoco.git -b 3.2.6
+git clone https://github.com/google-deepmind/mujoco.git -b 3.2.6
 cd mujoco
 mkdir build
 cd build

--- a/src/MuJoCoCarDemo.lf
+++ b/src/MuJoCoCarDemo.lf
@@ -13,7 +13,7 @@ target C {
   keepalive: true, // Because of physical action.
 }
 
-import MuJoCoCar from "lib/MujocoCar.lf"
+import MuJoCoCar from "lib/MuJoCoCar.lf"
 
 main reactor(period: time = 33333333 ns, speed_sensitivity: double = 0.05, turn_sensitivity: double = 0.01) {
   timer t(0, period)

--- a/src/include/mujoco.cmake
+++ b/src/include/mujoco.cmake
@@ -1,10 +1,7 @@
-if(CMAKE_SYSTEM_NAME MATCHES "Linux")
-  set(MUJOCO_PATH /opt/mujoco-3.2.6-linux-x86_64/mujoco-3.2.6/)
-elseif (CMAKE_SYSTEM_NAME MATCHES "Darwin")
-  set(MUJOCO_PATH /Application/MuJoCo.app/mujoco.framework)
-endif()
-
 # For Mujoco
+# If mujoco is installed to a different location, then the following variable
+# should be set to the correct path. See README.md
+set(MUJOCO_PATH "/opt/mujoco")
 list(APPEND CMAKE_PREFIX_PATH ${MUJOCO_PATH})
 find_library(MUJOCO_LIB mujoco REQUIRED)
 find_path(MUJOCO_INCLUDE_PATH mujoco REQUIRED)

--- a/src/include/mujoco.cmake
+++ b/src/include/mujoco.cmake
@@ -1,11 +1,17 @@
+if(CMAKE_SYSTEM_NAME MATCHES "Linux")
+  set(MUJOCO_PATH /opt/mujoco-3.2.6-linux-x86_64/mujoco-3.2.6/)
+elseif (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+  set(MUJOCO_PATH /Application/MuJoCo.app/mujoco.framework)
+endif()
+
 # For Mujoco
-list(APPEND CMAKE_PREFIX_PATH "/usr/local/")
-find_package(mujoco REQUIRED)
-target_include_directories(${LF_MAIN_TARGET} PUBLIC /usr/local/include)
-target_link_libraries(${LF_MAIN_TARGET} PUBLIC mujoco::mujoco)
+list(APPEND CMAKE_PREFIX_PATH ${MUJOCO_PATH})
+find_library(MUJOCO_LIB mujoco REQUIRED)
+find_path(MUJOCO_INCLUDE_PATH mujoco REQUIRED)
+target_include_directories(${LF_MAIN_TARGET} PUBLIC ${MUJOCO_INCLUDE_PATH})
+target_link_libraries(${LF_MAIN_TARGET} PUBLIC ${MUJOCO_LIB})
 
 # For GLFW
-list(APPEND CMAKE_PREFIX_PATH "/opt/homebrew/")
-find_package(glfw3 3.4 REQUIRED)
-target_include_directories(${LF_MAIN_TARGET} PUBLIC /opt/homebrew/include)
+find_package(glfw3 REQUIRED)
+target_include_directories(${LF_MAIN_TARGET} PUBLIC ${glfw3_INCLUDE_DIRS})
 target_link_libraries(${LF_MAIN_TARGET} PUBLIC glfw)

--- a/src/lib/MuJoCoCar.lf
+++ b/src/lib/MuJoCoCar.lf
@@ -6,7 +6,7 @@ target C {
   files: "../models/car.xml"
 }
 
-import MuJoCoBase from "MujocoBase.lf"
+import MuJoCoBase from "MuJoCoBase.lf"
 
 /**
  * @brief Model of a two-wheeled steerable vehicle.


### PR DESCRIPTION
I was struggling a bit to get it to compile and run on my Ubuntu24.04. It prompted some reading of Mujoco and CMake documentation. The Mujoco people recommend using their prebuilt binaries so I went with this, I have not tested it for macOS so I was hoping that you, Edward, could verify that it works.

For Ubuntu, this depends on merging https://github.com/lf-lang/lingua-franca/pull/2454