### PR TITLE
Add Inverted Pendulum example and adjust lib reactors

### DIFF
--- a/src/InvertedPendulum.lf
+++ b/src/InvertedPendulum.lf
@@ -1,0 +1,315 @@
+/*
+ * InvertedPendulum.lf
+ *
+ * Inverted-pendulum stabilisation with a cascade PID controller.
+ *
+ * Inner loop  – balances the pole (angle → force)
+ * Outer loop  – returns the cart to cart_pos = 0 (position → angle setpoint)
+ *
+ * @author Claude.ai
+ * @author Edward A. Lee
+ * @author Chadlia Jerad
+ */
+
+target C {
+  keepalive: true,
+  single-threaded: true,
+  cmake-include: ["include/mujoco.cmake"],
+  files: ["models/inverted_pendulum.xml"]
+}
+
+import MuJoCoAuto from "lib/MuJoCoAuto.lf"
+
+preamble {=
+  #include <stdio.h>
+  #include <stdlib.h>
+  #include <string.h>
+  #include <math.h>
+  #include <mujoco/mujoco.h>
+  #include <GLFW/glfw3.h>
+
+  #ifndef KEYPRESS_TYPES_H
+  #define KEYPRESS_TYPES_H
+  typedef struct {
+    int key;
+    int scancode;
+    int act;
+    int mods;
+  } keypress_t;
+  #endif // KEYPRESS_TYPES_H
+
+  typedef struct {
+    double kp, ki, kd;
+    double integral;
+    double prev_error;
+    double integral_limit, output_limit;
+    double dt;          /* sample period in seconds */
+  } PID;
+=}
+
+reactor InvertedPendulumSim(
+    model_file: string = {= LF_SOURCE_GEN_DIRECTORY LF_FILE_SEPARATOR "inverted_pendulum.xml" =},
+    control_step: time = 5 ms
+) extends MuJoCoAuto {
+
+  input force: double
+  input disturbance: double
+  
+  output cart_pos: double
+  output cart_vel: double
+  output pole_angle: double
+  output pole_angle_vel: double
+
+  timer control_timer(0, control_step)
+
+  state hinge_id: int
+  state s_cart_pos: int
+  state s_cart_vel: int
+  state s_pole_angle: int
+  state s_pole_angle_vel: int
+  state act_force: int
+  state latest_force: double
+
+  state step_count: long = 0
+
+  reaction(startup) {=
+    // Small initial perturbation so pole must be caught 
+    self->hinge_id = mj_name2id(self->context.m, mjOBJ_JOINT, "hinge");
+    self->context.d->qpos[self->context.m->jnt_qposadr[self->hinge_id]] = 0.05;  /* 0.05 rad ≈ 3° */
+
+    // Sensor address lookup 
+    self->s_cart_pos   = mj_name2id(self->context.m, mjOBJ_SENSOR, "cart_pos");
+    self->s_cart_vel   = mj_name2id(self->context.m, mjOBJ_SENSOR, "cart_vel");
+    self->s_pole_angle = mj_name2id(self->context.m, mjOBJ_SENSOR, "pole_angle");
+    self->s_pole_angle_vel   = mj_name2id(self->context.m, mjOBJ_SENSOR, "pole_angle_vel");
+    
+    // Actuator address 
+    self->act_force = mj_name2id(self->context.m, mjOBJ_ACTUATOR, "force");
+
+    // Start the simulation, initializing sim_start and wall_start 
+    self->sim_start   = self->context.d->time;
+    self->wall_start  = glfwGetTime();
+  =}
+
+  reaction(force) {=
+    self->latest_force = force->value;
+    self->context.d->ctrl[self->act_force] = self->latest_force;
+  =}
+
+  reaction(disturbance) {=
+    self->context.d->qvel[self->context.m->jnt_dofadr[self->s_pole_angle]] += disturbance->value;
+    lf_print("  [Disturbance] Applied impulse: %+5.2f rad/s", disturbance->value);
+  =}
+
+  reaction(physics_timer) {=
+    self->step_count++;
+    
+    if (self->step_count % 1000 == 0) {
+      double p_angle = self->context.d->sensordata[self->s_pole_angle];
+      double c_pos = self->context.d->sensordata[self->s_cart_pos];
+      snprintf(self->text_to_overlay, OVERLAY_BUF_SIZE, 
+              "Time=%6.1fs:     Angle=%+7.2f rad (%+5.1f deg)     Cart pos=%+4.3f m     F=%+4.1f N",
+              lf_time_logical_elapsed() / 1e9,
+              p_angle, p_angle * 180.0 / 3.14159, c_pos, self->latest_force);
+    }
+  =}
+  
+  reaction(control_timer) -> cart_pos, cart_vel, pole_angle, pole_angle_vel {=
+    double p_angle = self->context.d->sensordata[self->s_pole_angle];
+    double c_pos = self->context.d->sensordata[self->s_cart_pos];
+    double p_vel = self->context.d->sensordata[self->s_pole_angle_vel];
+    double c_vel = self->context.d->sensordata[self->s_cart_vel];
+    lf_set(cart_pos , c_pos);
+    lf_set(cart_vel, c_vel);
+    lf_set(pole_angle_vel, p_vel);
+    lf_set(pole_angle, p_angle);
+  =}
+}
+
+
+reactor InvertedPendulumPID (control_step: time = 5 ms) {
+  preamble {=
+    #include <math.h>
+    static void pid_init(PID *p, 
+      double kp, double ki, double kd, 
+      double integral_limit, double output_limit,
+      double dt) {
+        p->kp = kp; p->ki = ki; p->kd = kd;
+        p->integral_limit = integral_limit;
+        p->output_limit = output_limit;
+        p->integral = 0.0; p->prev_error = 0.0;
+        p->dt = dt;
+    }
+
+    static inline double pid_clamp(double val, double lo, double hi) {
+      return val < lo ? lo : (val > hi ? hi : val);
+    }
+
+    static double pid_update(PID *p, double setpoint, double measurement) {
+        double error = setpoint - measurement;
+
+        /* Proportional */
+        double Pout = p->kp * error;
+
+        /* Integral (Euler forward, anti-windup via simple clamp below) */
+        p->integral += error * p->dt;
+        double Iout = p->ki * p->integral;
+        /* Clamp integral term to prevent windup if values are provided */
+        if (p->integral_limit > 0.0) {
+          Iout = pid_clamp(Iout, -p->integral_limit, p->integral_limit);
+        }
+
+        /* Derivative on measurement (not error) – avoids derivative kick
+           on setpoint steps */
+        double derivative = (error - p->prev_error) / p->dt;
+        double Dout = p->kd * derivative;
+
+        p->prev_error = error;
+        double output = Pout + Iout + Dout;
+
+        /* Clamp total output if limits are provided */
+        if (p->output_limit > 0.0) {
+          output = pid_clamp(output, -p->output_limit, p->output_limit);
+        }
+
+        return output;
+    }
+  =}
+
+  input cart_pos: double
+  input pole_angle: double
+  input do_reset: bool
+  output force: double
+
+  state inner: PID
+  state outer: PID
+
+  reaction(startup) {=
+    double dt = (double)(self->control_step * 1e-9);
+    pid_init(&self->inner, 120.0, 1.0, 30.0, 10, 0, dt);
+    pid_init(&self->outer, -1.0, -0.1, -1.0, 0, 0.1, dt);
+  =}
+
+  reaction(cart_pos, pole_angle) -> force {=
+    // Outer loop: cart position → desired pole angle
+    //   setpoint for cart is x = 0
+    //   a positive cart offset → tilt pole slightly forward
+    //   to drive cart back                                   
+    double desired_angle = pid_update(&self->outer, cart_pos->value, 0.0);
+
+    // Inner loop: pole angle → cart force
+    double force_val = pid_update(&self->inner, pole_angle->value, desired_angle);
+    lf_set(force, force_val);
+  =}
+
+  reaction(do_reset) {=
+     self->inner.integral = 0.0;
+     self->outer.integral = 0.0;  
+     self->inner.prev_error = 0.0;
+     self->outer.prev_error = 0.0;
+  =}
+}
+
+/**
+ * Data logger for CSV output.
+ */
+reactor DataLogger(filename: string = "pendulum_data.csv") {
+  preamble {=
+    #include <stdio.h>
+  =}
+  
+  input pole_angle: double
+  input pole_angle_vel: double
+  input cart_pos: double
+  input cart_vel: double
+  input force: double
+  
+  state log_file: FILE* = {= NULL =}
+  state sample_count: int = 0
+  
+  reaction(startup) {=
+    self->log_file = fopen(self->filename, "w");
+    if (self->log_file) {
+      fprintf(self->log_file, "time_s,pole_angle_rad,pole_angle_vel_rad_s,cart_pos_m,cart_vel_m_s,force_N\n");
+      lf_print("Data logger: writing to %s", self->filename);
+    }
+  =}
+  
+  reaction(force) pole_angle, pole_angle_vel, cart_pos, cart_vel {=
+    if (self->log_file) {
+      fprintf(self->log_file, "%.6f,%.6f,%.6f,%.6f,%.6f,%.6f\n",
+              lf_time_logical_elapsed() / 1e9,
+              pole_angle->value, pole_angle_vel->value,
+              cart_pos->value, cart_vel->value,
+              force->value);
+      self->sample_count++;
+    }
+  =}
+  
+  reaction(shutdown) {=
+    if (self->log_file) {
+      fclose(self->log_file);
+      lf_print("Data logger: wrote %d samples to file", self->sample_count);
+    }
+  =}
+}
+
+/*
+ * Main reactor that instantiates the simulation, controller, and logger.
+ */
+main reactor InvertedPendulum {
+  sim = new InvertedPendulumSim(sim_step = 1 ms, frame_period = 33 ms, control_step = 5 ms)
+  pid = new InvertedPendulumPID(control_step = 5 ms)
+  logger = new DataLogger(filename = "pendulum_data.csv")
+
+  sim.cart_pos -> pid.cart_pos after 0
+  sim.pole_angle -> pid.pole_angle after 0
+  pid.force -> sim.force
+
+  // Data logging
+  sim.pole_angle -> logger.pole_angle
+  sim.pole_angle_vel -> logger.pole_angle_vel
+  sim.cart_pos -> logger.cart_pos
+  sim.cart_vel -> logger.cart_vel
+  pid.force -> logger.force
+  
+  reaction(startup) {=
+    lf_print(" ");
+    lf_print("========================================================================");
+    lf_print("   Inverted Pendulum Control using MuJoCo + Cascade PID Controllers");
+    lf_print("========================================================================");
+    lf_print(" ");
+    lf_print("Controls:");
+    lf_print("  Q         - Quit");
+    lf_print("  R/Backsp  - Reset simulation");
+    lf_print("  \u2190         - Apply left disturbance");
+    lf_print("  \u2192         - Apply right disturbance");
+    lf_print(" ");
+  =}
+  
+  // Handle key presses from the simulation (inherited from MuJoCoBase)
+  reaction(sim.key) -> sim.restart, sim.disturbance, pid.do_reset {=
+    if (sim.key->value.act == GLFW_PRESS) {
+      if (sim.key->value.key == GLFW_KEY_Q) {
+        lf_print("Quit requested");
+        lf_request_stop();
+      } else if (sim.key->value.key == GLFW_KEY_BACKSPACE || 
+                 sim.key->value.key == GLFW_KEY_R) {
+        lf_set(sim.restart, true);
+        lf_set(pid.do_reset, true);
+      } else if (sim.key->value.key == GLFW_KEY_LEFT) {
+        lf_set(sim.disturbance, -0.5);
+      } else if (sim.key->value.key == GLFW_KEY_RIGHT) {
+        lf_set(sim.disturbance, 0.5); 
+      }
+    }
+  =}
+  
+  reaction(shutdown) {=
+    lf_print(" ");
+    lf_print("========================================================================");
+    lf_print("                        Simulation Complete");
+    lf_print("========================================================================");
+    lf_print("  Data saved to: pendulum_data.csv");
+    lf_print(" ");
+  =}}

--- a/src/MuJoCoCarAutoDemo.lf
+++ b/src/MuJoCoCarAutoDemo.lf
@@ -24,6 +24,7 @@ main reactor(speed_sensitivity: double = 0.05, turn_sensitivity: double = 0.01) 
   reaction(startup) {=
     lf_print("*** Backspace to reset.");
     lf_print("*** Type q to quit.\n");
+    snprintf(self->text_to_overlay, OVERLAY_BUF_SIZE, "MuJoCo Car Auto Demo");
   =}
 
   reaction(m.key) -> m.restart, m.forward, m.turn {=

--- a/src/lib/MuJoCoAdvance.lf
+++ b/src/lib/MuJoCoAdvance.lf
@@ -24,6 +24,6 @@ reactor MuJoCoAdvance extends MuJoCoBase {
       return;
     }
     advance_simulator();
-    update_scene();
+    update_scene("");
   =}
 }

--- a/src/lib/MuJoCoAuto.lf
+++ b/src/lib/MuJoCoAuto.lf
@@ -8,38 +8,56 @@ import MuJoCoBase from "MuJoCoBase.lf"
  *
  * See [README.md](../README.md) for prerequisites and installation instructions.
  *
- * This reactor extends the base class to advance the simulation automatically and output a `tick`
- * event at each step. In addition, it will periodically update the display with period given by the
- * `frame_period` parameter, which defaults to 33 ms.
- *
+ * This reactor extends the base class to advance the simulation automatically using a  
+ * physics timer and output a `tick` event at each step. The `sim_step` parameter,
+ * which defaults to 1 ms, determines the time step for the physics simulation.
+ * In addition, it will periodically update the display with period given by the
+ * `frame_period` parameter, which defaults to 33 ms, using rendering timer. 
+ * 
  * @author Edward A. Lee
  */
-reactor MuJoCoAuto(frame_period: time = 33 ms) extends MuJoCoBase {
+reactor MuJoCoAuto(frame_period: time = 33 ms, sim_step: time =1 ms) extends MuJoCoBase {
+
+  preamble {=
+    #define OVERLAY_BUF_SIZE 100
+  =}
+
   output tick: bool
 
-  timer t(0, frame_period)
-  logical action advance
+  timer rendering_timer(0, frame_period)
+  timer physics_timer(0, sim_step)
 
-  reaction(startup) -> advance {=
-    lf_schedule(advance, 0);
+  state sim_start: double
+  state wall_start: double
+
+  state text_to_overlay: char[]   // Buffer for text to overlay on the display.
+
+  reaction(startup) {=
+    self->text_to_overlay = (char*)malloc(OVERLAY_BUF_SIZE * sizeof(char));
+    snprintf(self->text_to_overlay, OVERLAY_BUF_SIZE, "MuJoCo Simulation Starting...");
   =}
 
-  reaction(t) {=
-    update_scene();
+  reaction(rendering_timer) {=
+    update_scene(self->text_to_overlay);
   =}
 
-  reaction(advance) -> tick, advance {=
+reaction(physics_timer) -> tick {=
     lf_set(tick, true);
     if (glfwWindowShouldClose(self->window)) {
       lf_request_stop();
       return;
     }
-    self->mujoco_time = self->context.d->time; // Time before step.
+
+    // Real-time pacing: if the simulation is running faster than real time, sleep briefly 
+    // to let real time catch up.
+    double sim_time_elapsed  = self->context.d->time - self->sim_start;
+    double wall_time_elapsed = glfwGetTime() - self->wall_start;
+    interval_t delta_ns = (interval_t)(self->sim_step * 1e9);
+    if (sim_time_elapsed > wall_time_elapsed + delta_ns) {
+        // Physics is ahead of wall clock: sleep briefly
+        // (glfwWaitEventsTimeout caps at ~1 frame)
+        glfwWaitEventsTimeout(sim_time_elapsed - wall_time_elapsed - delta_ns);
+    }
     mj_step(self->context.m, self->context.d);
-    double delta = self->context.d->time - self->mujoco_time; // Time advanced.
-    interval_t delta_ns = (interval_t)(delta * 1e9);
-    // printf("delta = %f, ns = %lld\n", delta, delta_ns);
-    lf_schedule(advance, delta_ns);
-    self->lf_time = lf_time_logical();
   =}
 }

--- a/src/lib/MuJoCoAuto.lf
+++ b/src/lib/MuJoCoAuto.lf
@@ -12,11 +12,12 @@ import MuJoCoBase from "MuJoCoBase.lf"
  * physics timer and output a `tick` event at each step. The `sim_step` parameter,
  * which defaults to 1 ms, determines the time step for the physics simulation.
  * In addition, it will periodically update the display with period given by the
- * `frame_period` parameter, which defaults to 33 ms, using rendering timer. 
+ * `frame_period` parameter, which defaults to 33 ms, using a rendering timer. 
  * 
- * @author Edward A. Lee
+* @author Edward A. Lee
+* @author Chadlia Jerad
  */
-reactor MuJoCoAuto(frame_period: time = 33 ms, sim_step: time =1 ms) extends MuJoCoBase {
+reactor MuJoCoAuto(frame_period: time = 33 ms, sim_step: time = 1 ms) extends MuJoCoBase {
 
   preamble {=
     #define OVERLAY_BUF_SIZE 100

--- a/src/lib/MuJoCoBase.lf
+++ b/src/lib/MuJoCoBase.lf
@@ -34,12 +34,15 @@ preamble {=
     void* keypress;
   } mujoco_instance_t;
 
+  #ifndef KEYPRESS_TYPES_H
+  #define KEYPRESS_TYPES_H
   typedef struct {
     int key;
     int scancode;
     int act;
     int mods;
   } keypress_t;
+  #endif // KEYPRESS_TYPES_H
 
   #endif // MUJOCO_H
 =}
@@ -168,7 +171,7 @@ reactor MuJoCoBase(
   =}
 
   // Update the scene.
-  method update_scene() {=
+  method update_scene(text_to_overlay: string) {=
     // get framebuffer viewport
     mjrRect viewport = {0, 0, 0, 0};
     glfwGetFramebufferSize(self->window, &viewport.width, &viewport.height);
@@ -176,6 +179,15 @@ reactor MuJoCoBase(
     // update scene and render
     mjv_updateScene(self->context.m, self->context.d, &self->context.opt, NULL, &self->context.cam, mjCAT_ALL, &self->context.scn);
     mjr_render(viewport, &self->context.scn, &self->context.con);
+
+    mjr_overlay(
+        mjFONT_SHADOW,           // font
+        mjGRID_BOTTOMLEFT,       // position
+        viewport,                // MjrRect viewport
+        text_to_overlay,             // line 1
+        NULL,         // line 2
+        &self->context.con                     // mjrContext*
+    );
 
     // swap OpenGL buffers (blocking call due to v-sync)
     glfwSwapBuffers(self->window);
@@ -228,6 +240,12 @@ reactor MuJoCoBase(
     // create scene and context
     mjv_makeScene(m, &self->context.scn, 2000);
     mjr_makeContext(m, &self->context.con, mjFONTSCALE_150);
+
+
+    /* Camera position */
+    self->context.cam.lookat[2]  = 0.5;
+    self->context.cam.distance   = 5;
+    self->context.cam.elevation  = -20.0;
 
     // install GLFW mouse and keyboard callbacks
     glfwSetKeyCallback(self->window, keyboard);

--- a/src/lib/MuJoCoCarAuto.lf
+++ b/src/lib/MuJoCoCarAuto.lf
@@ -61,22 +61,22 @@ reactor MuJoCoCarAuto(
   =}
 
   reaction(restart) {=
-    advance_simulator();
+    // advance_simulator();
     self->context.d->ctrl[self->forward_index] = 0.0;
     self->context.d->ctrl[self->turn_index] = 0.0;
   =}
 
   reaction(forward) {=
-    advance_simulator();
+    // advance_simulator();
     self->context.d->ctrl[self->forward_index] = forward->value;
   =}
 
   reaction(turn) {=
-    advance_simulator();
+    // advance_simulator();
     self->context.d->ctrl[self->turn_index] = turn->value;
   =}
 
-  reaction(advance) -> right_force, left_force {=
+  reaction(physics_timer) -> right_force, left_force {=
     // Output sensor data.
     lf_set(right_force, self->context.d->sensordata[self->right_address]);
     lf_set(left_force, self->context.d->sensordata[self->left_address]);

--- a/src/models/inverted_pendulum.xml
+++ b/src/models/inverted_pendulum.xml
@@ -1,0 +1,79 @@
+<!-- inverted_pendulum.xml -->
+<mujoco model="inverted_pendulum">
+  <!-- Simulation parameters -->
+  <option integrator="RK4" gravity="0 0 -9.81"/>
+
+  <!-- Visual settings for rendering -->
+  <visual>
+    <headlight diffuse="0.6 0.6 0.6" ambient="0.4 0.4 0.4" specular="0 0 0"/>
+    <rgba haze="0.15 0.25 0.35 1"/>
+    <global azimuth="120" elevation="-20"/>
+  </visual>
+
+    <!-- Material definitions -->
+  <asset>
+    <texture type="skybox" builtin="gradient" rgb1="0.3 0.5 0.7" rgb2="0 0 0" 
+             width="512" height="512"/>
+    <texture type="2d" name="groundplane" builtin="checker" mark="edge" 
+             rgb1="0.2 0.3 0.4" rgb2="0.1 0.15 0.2" markrgb="0.8 0.8 0.8" 
+             width="300" height="300"/>
+    <material name="groundplane" texture="groundplane" texuniform="true" 
+              texrepeat="5 5" reflectance="0.2"/>
+    <material name="cart_material" rgba="0.4 0.6 0.8 1"/>
+    <material name="pole_material" rgba="0.8 0.3 0.2 1"/>
+    <material name="track_material" rgba="0.5 0.5 0.5 1"/>
+  </asset>
+
+  <!-- Physical parameters with realistic values -->
+  <default>
+    <joint armature="0.01" damping="0.1" limited="true"/>
+    <geom contype="1" conaffinity="1" condim="3" friction="1 0.5 0.5"/>
+  </default>
+  
+  <worldbody>
+    <!-- Ground plane for visual reference -->
+    <geom name="floor" type="plane" size="5 5 0.1" material="groundplane"/>
+    
+    <!-- Track/rail for the cart (visual only) -->
+    <geom name="track" type="box" pos="0 0 0" size="2.5 0.05 0.02" 
+          material="track_material"
+          contype="0" conaffinity="0"/>
+
+    <!-- Cart: slides along X axis -->
+    <body name="cart" pos="0 0 0.05">
+      <joint name="slider" type="slide" axis="1 0 0"
+             range="-3 3" damping="0.5"/>
+      <geom type="box" size="0.2 0.1 0.05" mass="0.5"
+            rgba="0.3 0.5 0.9 1"/>
+
+      <!-- Pendulum: rotates in XZ plane, mounted on top of cart -->
+      <body name="pole" pos="0 0 0.05">
+        <joint name="hinge" type="hinge" axis="0 1 0" range="-90 90"
+               damping="0.05"/>
+        <!-- Rod: half-length = 0.5 m  => full length 1 m, mass 0.1 kg -->
+        <geom type="capsule" fromto="0 0 0  0 0 1.0"
+              size="0.025" mass="0.1" rgba="0.9 0.4 0.2 1"/>
+        <!-- Bob at tip -->
+        <geom type="sphere" pos="0 0 1.0" size="0.05"
+              mass="0.01" rgba="0.9 0.9 0.1 1"/>
+      </body>
+    </body>
+    <camera name="main" mode="fixed" pos="0 -4.5 1.5" xyaxes="1 0 0 0 0 1"/>
+  </worldbody>
+
+  <actuator>
+    <!-- Force actuator on the cart slider.
+         gear="1" means 1 N per unit control signal.
+         ctrlrange limits the force to ±20 N. -->
+    <motor name="force" joint="slider" gear="1"
+           ctrlrange="-20 20" ctrllimited="true"/>
+  </actuator>
+
+  <sensor>
+    <jointpos  name="cart_pos"   joint="slider"/>
+    <jointvel  name="cart_vel"   joint="slider"/>
+    <jointpos  name="pole_angle" joint="hinge"/>
+    <jointvel  name="pole_angle_vel"   joint="hinge"/>
+  </sensor>
+
+</mujoco>


### PR DESCRIPTION
This PR adds the Inverted Pendulum example. Stabilization is achieved using two cascaded PID controllers that operate without velocity feedback. A disturbance can be injected during the simulation using the left and right arrow keys.

The PR also introduces minor updates to `src/lib/MuJoCoBase.lf` and `src/lib/MuJoCoAuto.lf`:
- Use of a timer (`physics_timer`) to automatically advance the simulation.
- Support for printing messages at the bottom of the simulation display.

The remaining library and example files were updated accordingly to accommodate these changes.
