### PR TITLE
Add examples for Car line following and Platoon

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,3 +115,5 @@ Build the demos using `lfc` or `make`:
 * [CarAuto](src/CarAuto.lf): Simple drivable car.
 * [InvertedPendulum](src/InvertedPendulum.lf): Inverted pendulum demo.
 * [Panda](src/Panda.lf): Franka Emika Panda robot doing gyrations.
+* [CarLineFollow](src/CarLineFollow.lf): Single car following a figure-8 track using five line rangefinders and a PD controller.
+* [CarPlatoon](src/CarPlatoon.lf): Platoon of three line-following cars with gap-keeping and emergency-stop logic.

--- a/src/CarLineFollow.lf
+++ b/src/CarLineFollow.lf
@@ -1,0 +1,323 @@
+/**
+ * Line-following car on a figure-8 track in MuJoCo.
+ *
+ * Five downward rangefinders (ll, l, c, r, rr) feed a PID controller.
+ * Sensor readings: ~0.025 m over track strip, ~0.030 m over bare floor.
+ * Error = weighted lateral offset: (-2·ll - l + r + 2·rr) / (sum + ε)
+ *   > 0 → drifted left  → turn right
+ *   < 0 → drifted right → turn left
+ *
+ * Keys: M toggle auto/manual  ↑↓←→ manual drive  Backspace reset  Q quit
+ *
+ * @author Chadlia Jerad
+ */
+target C {
+  keepalive: true,
+  files: ["models/car_line_follow.xml", "models/track.xml", "models/car_sensor_rich.xml"]
+}
+
+import MuJoCoAuto from "lib/MuJoCoAuto.lf"
+
+preamble {=
+  typedef struct {
+    double line_ll, line_l, line_c, line_r, line_rr;
+  } sensor_reading_t;
+
+  typedef struct {
+    double forward;      /* [0..1] */
+    double turn;         /* [-1..1] */
+  } control_command_t;
+=}
+
+reactor MuJoCuEnvSim(
+    model_file: string = {= LF_SOURCE_GEN_DIRECTORY LF_FILE_SEPARATOR "car_line_follow.xml" =}
+) extends MuJoCoAuto {
+
+  input sense: bool
+  input mode_change: bool
+
+  output sensor_reading: sensor_reading_t
+  input ctrl_cmd: control_command_t
+
+  state forward_index: int = 0
+  state turn_index: int = 0
+  state line_ll_address: int = 0
+  state line_l_address: int = 0
+  state line_c_address: int = 0
+  state line_r_address: int = 0
+  state line_rr_address: int = 0
+  state sensor_values: sensor_reading_t = {0};
+  state auto_mode: bool = true
+  state step_count: int = 0
+
+  method read_sensors() : sensor_reading_t {=
+    sensor_reading_t rs = {
+      .line_ll = self->context.d->sensordata[self->line_ll_address],
+      .line_l = self->context.d->sensordata[self->line_l_address],
+      .line_c = self->context.d->sensordata[self->line_c_address],
+      .line_r = self->context.d->sensordata[self->line_r_address],
+      .line_rr = self->context.d->sensordata[self->line_rr_address],
+    };
+    return rs;
+  =}
+
+  reaction(startup) {=
+    self->forward_index = mj_name2id(self->context.m, mjOBJ_ACTUATOR, "car_forward");
+    self->turn_index    = mj_name2id(self->context.m, mjOBJ_ACTUATOR, "car_turn");
+    int ll_idx         = mj_name2id(self->context.m, mjOBJ_SENSOR, "car_line_ll");
+    int l_idx          = mj_name2id(self->context.m, mjOBJ_SENSOR, "car_line_l");
+    int c_idx         = mj_name2id(self->context.m, mjOBJ_SENSOR, "car_line_c");
+    int r_idx         = mj_name2id(self->context.m, mjOBJ_SENSOR, "car_line_r");
+    int rr_idx         = mj_name2id(self->context.m, mjOBJ_SENSOR, "car_line_rr");
+
+    if (self->forward_index < 0 || self->turn_index < 0 ||
+        ll_idx < 0 || l_idx < 0 || c_idx < 0 || r_idx < 0 || rr_idx < 0) {
+      lf_print_error("Mismatched model file. Missing sensors or actuators.");
+      lf_request_stop();
+      return;
+    }
+    if (self->context.m->sensor_dim[ll_idx]    != 1 ||
+        self->context.m->sensor_dim[l_idx]     != 1 ||
+        self->context.m->sensor_dim[c_idx]    != 1 ||
+        self->context.m->sensor_dim[r_idx]    != 1 ||
+        self->context.m->sensor_dim[rr_idx]    != 1) {
+      lf_print_error("Mismatched model file. Expected scalar sensors.");
+      lf_request_stop();
+      return;
+    }
+
+    self->line_ll_address  = self->context.m->sensor_adr[ll_idx];
+    self->line_l_address = self->context.m->sensor_adr[l_idx];
+    self->line_c_address = self->context.m->sensor_adr[c_idx];
+    self->line_r_address = self->context.m->sensor_adr[r_idx];
+    self->line_rr_address = self->context.m->sensor_adr[rr_idx];
+  =}
+
+  reaction(restart) {=
+    self->context.d->ctrl[self->forward_index] = 0.0;
+    self->context.d->ctrl[self->turn_index]    = 0.0;
+  =}
+
+  reaction(physics_timer) {=
+    self->step_count++;
+    self->sensor_values = read_sensors();
+
+    if (self->step_count % 1000 == 0) {
+      snprintf(self->text_to_overlay, OVERLAY_BUF_SIZE,
+              "Time=%6.1fs: LL:%.4f L:%.4f C:%.4f R:%.4f RR:%.4f [%s]",
+              lf_time_logical_elapsed() / 1e9,
+              self->sensor_values.line_ll,self->sensor_values.line_l, 
+              self->sensor_values.line_c, 
+              self->sensor_values.line_r, self->sensor_values.line_rr,
+              self->auto_mode ? "AUTO" : "MANUAL");
+    }
+
+  =}
+
+  reaction(sense) -> sensor_reading {=
+    self->sensor_values = read_sensors();
+    lf_set(sensor_reading, self->sensor_values);
+  =}
+
+  reaction(ctrl_cmd) {=
+    self->context.d->ctrl[self->forward_index] = ctrl_cmd->value.forward;
+    self->context.d->ctrl[self->turn_index] = ctrl_cmd->value.turn;
+  =}
+
+  reaction(mode_change) {=
+    self->auto_mode = mode_change->value;
+    lf_print("====mode changed to %d", self->auto_mode);
+  =}
+
+}
+
+
+reactor Car(
+    auto_speed: double = 0.30,      // forward control in auto mode  [0..1]
+    kp: double = 2.5,
+    ki: double = 0.2,
+    kd: double = 1.5,
+    speed_kp:  double = 0.8,        // how aggressively to slow on curves
+    min_speed: double = 0.15,       // minimum forward control in auto mode (must be < auto_speed)
+    speed_sensitivity: double = 0.05,
+    turn_sensitivity: double = 0.01
+) {
+
+  timer sense_timer(0, 10 ms)
+  input sensor_reading: sensor_reading_t
+  input key_cmd: int
+
+  output sense: bool
+  output mode_change: bool
+  output ctrl_cmd: control_command_t
+
+  state speed: double = 0.0
+  state turn: double = 0.0
+  state auto_mode: bool = true
+  state integral: double = 0.0
+  state prev_error: double = 0.0
+  state filtered_deriv: double = 0.0  // EMA-filtered derivative — suppresses 10 ms noise
+
+  initial mode Auto {
+    reaction(sense_timer) -> sense {=
+      // Read the line sensors every timer period
+      lf_set(sense, true);
+    =}
+
+    reaction(key_cmd) -> Manual, mode_change, ctrl_cmd {=
+      int key = key_cmd->value;
+      if (key == 'Z') {
+        self->speed = 0.0;
+        self->turn  = 0.0;
+      } else if (key == 'M') {
+        self->auto_mode = !self->auto_mode;
+        lf_print("*** Manual mode ON");
+        lf_set(mode_change, self->auto_mode);
+
+        // Zero the actuators immediately — without this the last auto ctrl_cmd
+        // stays active in MuJoCo 
+        self->turn  = 0.0;
+        self->integral = 0.0;
+        self->filtered_deriv = 0.0;
+        control_command_t stop = {.forward = 0.0, .turn = 0.0};
+        lf_set(ctrl_cmd, stop);
+        lf_set_mode(Manual);
+      }
+    =}
+
+    reaction(sensor_reading) -> ctrl_cmd {=
+      printf("\r" PRINTF_TIME, lf_time_logical_elapsed());
+      printf("  LL:%.4f L:%.4f C:%.4f R:%.4f RR:%.4f [%s]",
+          sensor_reading->value.line_ll,sensor_reading->value.line_l, 
+          sensor_reading->value.line_c, 
+          sensor_reading->value.line_r, sensor_reading->value.line_rr,
+          self->auto_mode ? "AUTO" : "MANUAL");
+      fflush(stdout);
+
+      if (!self->auto_mode) return;
+
+      double rr = sensor_reading->value.line_rr;
+      double r = sensor_reading->value.line_r;
+      double c = sensor_reading->value.line_c;
+      double l = sensor_reading->value.line_l;
+      double ll = sensor_reading->value.line_ll;
+      double total = ll + l + c + r + rr;
+      double error = (-2*ll - 1*l + 0*c + 1*r + 2*rr) / (total + 1e-6);  // error in [-2,2], scaled by total signal to reduce noise when weak readings
+
+      double dt = 0.01;  // matches sense_timer period (10 ms)
+
+      double proportional = error;
+
+      self->integral += error * dt;
+      if (self->integral >  1.0 / self->ki) self->integral =  1.0 / self->ki;
+      if (self->integral < -1.0 / self->ki) self->integral = -1.0 / self->ki;
+
+      // EMA (α=0.25): suppresses 10 ms jitter amplified by 1/dt=100×.
+      double raw_deriv     = (error - self->prev_error) / dt;
+      self->filtered_deriv = 0.25 * raw_deriv + 0.75 * self->filtered_deriv;
+      self->prev_error     = error;
+
+      double ctrl_turn = self->kp * proportional
+                      + self->ki * self->integral
+                      + self->kd * self->filtered_deriv;
+
+      if (ctrl_turn >  1.0) ctrl_turn =  1.0;
+      if (ctrl_turn < -1.0) ctrl_turn = -1.0;
+
+      // Slow on curves, floor at min_speed.
+      double abs_error   = error < 0 ? -error : error;
+      double speed_scale = 1.0 - self->speed_kp * abs_error;
+      if (speed_scale < self->min_speed / self->auto_speed)
+          speed_scale = self->min_speed / self->auto_speed;
+
+      double forward_speed = self->auto_speed * speed_scale;
+
+      control_command_t cmd = {.forward = forward_speed, .turn = ctrl_turn};
+
+      lf_set(ctrl_cmd, cmd);
+
+    =}
+  }
+
+  mode Manual {
+    reaction(key_cmd) -> ctrl_cmd, Auto, mode_change {=
+      int key = key_cmd->value;
+      if (key == 'Z') {
+        self->speed = 0.0;
+        self->turn  = 0.0;
+      } else if (key == 'M') {
+        self->auto_mode = !self->auto_mode;
+        lf_print("*** Auto mode ON");
+        self->speed = 0.0;
+        self->turn  = 0.0;
+        lf_set(mode_change, self->auto_mode);
+        lf_set_mode(Auto);
+      } else if (!self->auto_mode) {
+        if (key == 'U') {
+          self->speed += self->speed_sensitivity;
+          // lf_set(forward, self->speed);
+        } else if (key == 'D') {
+          self->speed -= self->speed_sensitivity;
+          // lf_set(forward, self->speed);
+        } else if (key == 'R') {
+          self->turn -= self->turn_sensitivity;
+          // lf_set(turn, self->turn);
+        } else if (key == 'L') {
+          self->turn += self->turn_sensitivity;
+          // lf_set(turn, self->turn);
+        }
+      }
+      control_command_t cmd = {.forward = self->speed, .turn = self->turn};
+      lf_set(ctrl_cmd, cmd);
+    =}
+
+  }
+
+}
+
+main reactor {
+  m = new MuJoCuEnvSim()
+  c = new Car()
+
+  c.sense -> m.sense
+  c.mode_change -> m.mode_change
+  m.sensor_reading -> c.sensor_reading
+  c.ctrl_cmd -> m.ctrl_cmd
+
+  reaction(startup) {=
+    lf_print("*** Auto mode ON.  Press M to toggle manual / auto.");
+    lf_print("*** Arrow keys: manual drive.  Backspace: reset.  Q: quit.\n");
+    lf_print("MuJoCo version number: %d\n", mj_version());
+  =}
+
+  reaction(m.key) -> m.restart, c.key_cmd {=
+    if (m.key->value.act != GLFW_PRESS) return;
+    int key = m.key->value.key;
+    int cmd = 0;
+
+    if (key == GLFW_KEY_BACKSPACE) {
+      lf_set(m.restart, true);
+      cmd = 'Z';
+    } else if (key == GLFW_KEY_Q) {
+      lf_request_stop();
+    } else if (key == GLFW_KEY_M) {
+      cmd = 'M';
+    } else if (key == GLFW_KEY_UP) {
+      cmd = 'U';
+    } else if (key == GLFW_KEY_DOWN) {
+      cmd = 'D';
+    } else if (key == GLFW_KEY_RIGHT) {
+      cmd = 'R';
+    } else if (key == GLFW_KEY_LEFT) {
+      cmd = 'L';
+    }
+
+    if (cmd != 0) {
+      lf_set(c.key_cmd, cmd);
+    }
+  =}
+
+  reaction(shutdown) {=
+    lf_print("\nExiting.");
+  =}
+}

--- a/src/CarLineFollow.lf
+++ b/src/CarLineFollow.lf
@@ -143,7 +143,7 @@ reactor Car(
     turn_sensitivity: double = 0.01
 ) {
 
-  timer sense_timer(0, 10 ms)
+  timer sense_timer(0, 50 ms)
   input sensor_reading: sensor_reading_t
   input key_cmd: int
 
@@ -204,7 +204,7 @@ reactor Car(
       double total = ll + l + c + r + rr;
       double error = (-2*ll - 1*l + 0*c + 1*r + 2*rr) / (total + 1e-6);  // error in [-2,2], scaled by total signal to reduce noise when weak readings
 
-      double dt = 0.01;  // matches sense_timer period (10 ms)
+      double dt = 0.05;  // matches sense_timer period (50 ms)
 
       double proportional = error;
 

--- a/src/CarLineFollow.lf
+++ b/src/CarLineFollow.lf
@@ -134,12 +134,12 @@ reactor MuJoCuEnvSim(
 
 reactor Car(
     auto_speed: double = 0.30,      // forward control in auto mode  [0..1]
-    kp: double = 2.5,
-    ki: double = 0.2,
-    kd: double = 1.5,
-    dt: time = 50 ms,               // sense_timer period and PID update interval
-    speed_kp:  double = 0.8,        // how aggressively to slow on curves
-    min_speed: double = 0.15,       // minimum forward control in auto mode 
+    kp: double = 2.0,
+    kd: double = 1.0,
+    dt: time = 50 ms,
+    speed_kp: double = 0.8,
+    min_speed: double = 0.15,
+    lost_threshold: double = 0.0295,  // min sensor reading above this → line lost (~0.025 on strip, ~0.030 on floor)
     speed_sensitivity: double = 0.05,
     turn_sensitivity: double = 0.01
 ) {
@@ -155,13 +155,12 @@ reactor Car(
   state speed: double = 0.0
   state turn: double = 0.0
   state auto_mode: bool = true
-  state integral: double = 0.0
   state prev_error: double = 0.0
-  state filtered_deriv: double = 0.0  // EMA-filtered derivative — suppresses 10 ms noise
+  state filtered_deriv: double = 0.0  // EMA-filtered derivative
+  state search_dir: double = 1.0      // rotation direction when line is lost
 
   initial mode Auto {
     reaction(sense_timer) -> sense {=
-      // Read the line sensors every timer period
       lf_set(sense, true);
     =}
 
@@ -174,11 +173,9 @@ reactor Car(
         self->auto_mode = !self->auto_mode;
         lf_print("*** Manual mode ON");
         lf_set(mode_change, self->auto_mode);
-
-        // Zero the actuators immediately — without this the last auto ctrl_cmd
-        // stays active in MuJoCo 
+        // MuJoCo retains the last ctrl[] value — zero explicitly on mode switch.
+        self->speed = 0.0;
         self->turn  = 0.0;
-        self->integral = 0.0;
         self->filtered_deriv = 0.0;
         control_command_t stop = {.forward = 0.0, .turn = 0.0};
         lf_set(ctrl_cmd, stop);
@@ -188,7 +185,7 @@ reactor Car(
 
     reaction(sensor_reading) -> ctrl_cmd {=
       printf("\r" PRINTF_TIME, lf_time_logical_elapsed());
-      printf("  LL:%.4f L:%.4f C:%.4f R:%.4f RR:%.4f [%s]",
+      printf("  LL:%.4f  L:%.4f  C:%.4f  R:%.4f  RR:%.4f [%s]",
           sensor_reading->value.line_ll,sensor_reading->value.line_l, 
           sensor_reading->value.line_c, 
           sensor_reading->value.line_r, sensor_reading->value.line_rr,
@@ -198,43 +195,50 @@ reactor Car(
       if (!self->auto_mode) return;
 
       double rr = sensor_reading->value.line_rr;
-      double r = sensor_reading->value.line_r;
-      double c = sensor_reading->value.line_c;
-      double l = sensor_reading->value.line_l;
+      double r  = sensor_reading->value.line_r;
+      double c  = sensor_reading->value.line_c;
+      double l  = sensor_reading->value.line_l;
       double ll = sensor_reading->value.line_ll;
+
+      // Lost-line detection: all sensors read ~0.030 m (floor); track strip gives ~0.025 m.
+      double min_s = ll < l ? ll : l;
+      if (c   < min_s) min_s = c;
+      if (r   < min_s) min_s = r;
+      if (rr  < min_s) min_s = rr;
+      if (min_s > self->lost_threshold) {
+        control_command_t cmd = {.forward = 0.0, .turn = self->search_dir * 0.2};
+        lf_set(ctrl_cmd, cmd);
+        return;
+      }
+
       double total = ll + l + c + r + rr;
-      double error = (-2*ll - 1*l + 0*c + 1*r + 2*rr) / (total + 1e-6);  // error in [-2,2], scaled by total signal to reduce noise when weak readings
+      double error = (-2*ll - l + r + 2*rr) / (total + 1e-6);
 
-      double proportional = error;
+      // Keep search direction current while tracking.
+      if      (error >  0.1) self->search_dir =  1.0;
+      else if (error < -0.1) self->search_dir = -1.0;
 
-      self->integral += error * self->dt / 1e9;  // dt is in nanoseconds, convert to seconds
-      if (self->integral >  1.0 / self->ki) self->integral =  1.0 / self->ki;
-      if (self->integral < -1.0 / self->ki) self->integral = -1.0 / self->ki;
-
-      // EMA (α=0.25): suppresses 10 ms jitter amplified by 1/dt=100×.
-      double raw_deriv     = (error - self->prev_error) / self->dt / 1e9;
+      // PD with EMA derivative (α=0.25 suppresses sensor noise amplified by 1/dt).
+      double dt_s = (double)self->dt * 1e-9;
+      double raw_deriv = (error - self->prev_error) / dt_s;
       self->filtered_deriv = 0.25 * raw_deriv + 0.75 * self->filtered_deriv;
-      self->prev_error     = error;
+      self->prev_error = error;
 
-      double ctrl_turn = self->kp * proportional
-                      + self->ki * self->integral
-                      + self->kd * self->filtered_deriv;
-
+      double ctrl_turn = self->kp * error + self->kd * self->filtered_deriv;
       if (ctrl_turn >  1.0) ctrl_turn =  1.0;
       if (ctrl_turn < -1.0) ctrl_turn = -1.0;
 
-      // Slow on curves, floor at min_speed.
+      // Smooth speed reduction on curves; floor at min_speed.
       double abs_error   = error < 0 ? -error : error;
-      double speed_scale = 1.0 - self->speed_kp * abs_error;
+      double speed_scale = 1.0 / (1.0 + self->speed_kp * abs_error);
       if (speed_scale < self->min_speed / self->auto_speed)
           speed_scale = self->min_speed / self->auto_speed;
 
-      double forward_speed = self->auto_speed * speed_scale;
-
-      control_command_t cmd = {.forward = forward_speed, .turn = ctrl_turn};
-
+      control_command_t cmd = {
+          .forward = self->auto_speed * speed_scale,
+          .turn    = ctrl_turn
+      };
       lf_set(ctrl_cmd, cmd);
-
     =}
   }
 
@@ -252,19 +256,10 @@ reactor Car(
         lf_set(mode_change, self->auto_mode);
         lf_set_mode(Auto);
       } else if (!self->auto_mode) {
-        if (key == 'U') {
-          self->speed += self->speed_sensitivity;
-          // lf_set(forward, self->speed);
-        } else if (key == 'D') {
-          self->speed -= self->speed_sensitivity;
-          // lf_set(forward, self->speed);
-        } else if (key == 'R') {
-          self->turn -= self->turn_sensitivity;
-          // lf_set(turn, self->turn);
-        } else if (key == 'L') {
-          self->turn += self->turn_sensitivity;
-          // lf_set(turn, self->turn);
-        }
+        if      (key == 'U') self->speed += self->speed_sensitivity;
+        else if (key == 'D') self->speed -= self->speed_sensitivity;
+        else if (key == 'R') self->turn  -= self->turn_sensitivity;
+        else if (key == 'L') self->turn  += self->turn_sensitivity;
       }
       control_command_t cmd = {.forward = self->speed, .turn = self->turn};
       lf_set(ctrl_cmd, cmd);

--- a/src/CarLineFollow.lf
+++ b/src/CarLineFollow.lf
@@ -137,13 +137,14 @@ reactor Car(
     kp: double = 2.5,
     ki: double = 0.2,
     kd: double = 1.5,
+    dt: time = 50 ms,               // sense_timer period and PID update interval
     speed_kp:  double = 0.8,        // how aggressively to slow on curves
-    min_speed: double = 0.15,       // minimum forward control in auto mode (must be < auto_speed)
+    min_speed: double = 0.15,       // minimum forward control in auto mode 
     speed_sensitivity: double = 0.05,
     turn_sensitivity: double = 0.01
 ) {
 
-  timer sense_timer(0, 50 ms)
+  timer sense_timer(0, dt)
   input sensor_reading: sensor_reading_t
   input key_cmd: int
 
@@ -204,16 +205,14 @@ reactor Car(
       double total = ll + l + c + r + rr;
       double error = (-2*ll - 1*l + 0*c + 1*r + 2*rr) / (total + 1e-6);  // error in [-2,2], scaled by total signal to reduce noise when weak readings
 
-      double dt = 0.05;  // matches sense_timer period (50 ms)
-
       double proportional = error;
 
-      self->integral += error * dt;
+      self->integral += error * self->dt / 1e9;  // dt is in nanoseconds, convert to seconds
       if (self->integral >  1.0 / self->ki) self->integral =  1.0 / self->ki;
       if (self->integral < -1.0 / self->ki) self->integral = -1.0 / self->ki;
 
       // EMA (α=0.25): suppresses 10 ms jitter amplified by 1/dt=100×.
-      double raw_deriv     = (error - self->prev_error) / dt;
+      double raw_deriv     = (error - self->prev_error) / self->dt / 1e9;
       self->filtered_deriv = 0.25 * raw_deriv + 0.75 * self->filtered_deriv;
       self->prev_error     = error;
 

--- a/src/CarLineFollow.lf
+++ b/src/CarLineFollow.lf
@@ -10,8 +10,10 @@
  * Keys: M toggle auto/manual  ↑↓←→ manual drive  Backspace reset  Q quit
  *
  * @author Chadlia Jerad
+ * @author Edward A. Lee
  */
 target C {
+  workers: 1, // For macOS, all GLFW operations must be done on the main thread.
   keepalive: true,
   files: ["models/car_line_follow.xml", "models/track.xml", "models/car_sensor_rich.xml"]
 }
@@ -29,12 +31,11 @@ preamble {=
   } control_command_t;
 =}
 
-reactor MuJoCuEnvSim(
+reactor MuJoCuCarWithTrack(
     model_file: string = {= LF_SOURCE_GEN_DIRECTORY LF_FILE_SEPARATOR "car_line_follow.xml" =}
 ) extends MuJoCoAuto {
 
   input sense: bool
-  input mode_change: bool
 
   output sensor_reading: sensor_reading_t
   input ctrl_cmd: control_command_t
@@ -47,7 +48,6 @@ reactor MuJoCuEnvSim(
   state line_r_address: int = 0
   state line_rr_address: int = 0
   state sensor_values: sensor_reading_t = {0};
-  state auto_mode: bool = true
   state step_count: int = 0
 
   method read_sensors() : sensor_reading_t {=
@@ -104,12 +104,11 @@ reactor MuJoCuEnvSim(
 
     if (self->step_count % 1000 == 0) {
       snprintf(self->text_to_overlay, OVERLAY_BUF_SIZE,
-              "Time=%6.1fs: LL:%.4f L:%.4f C:%.4f R:%.4f RR:%.4f [%s]",
+              "Time=%6.1fs: LL:%.4f L:%.4f C:%.4f R:%.4f RR:%.4f",
               lf_time_logical_elapsed() / 1e9,
               self->sensor_values.line_ll,self->sensor_values.line_l, 
               self->sensor_values.line_c, 
-              self->sensor_values.line_r, self->sensor_values.line_rr,
-              self->auto_mode ? "AUTO" : "MANUAL");
+              self->sensor_values.line_r, self->sensor_values.line_rr);
     }
 
   =}
@@ -123,56 +122,53 @@ reactor MuJoCuEnvSim(
     self->context.d->ctrl[self->forward_index] = ctrl_cmd->value.forward;
     self->context.d->ctrl[self->turn_index] = ctrl_cmd->value.turn;
   =}
-
-  reaction(mode_change) {=
-    self->auto_mode = mode_change->value;
-    lf_print("====mode changed to %d", self->auto_mode);
-  =}
-
 }
 
 
-reactor Car(
-    auto_speed: double = 0.30,      // forward control in auto mode  [0..1]
-    kp: double = 2.0,
-    kd: double = 1.0,
+reactor Controller(
+    kp: double = 1.0,
+    kd: double = 0.1,
     dt: time = 50 ms,
-    speed_kp: double = 0.8,
+    speed_kp: double = 2.0,
     min_speed: double = 0.15,
     lost_threshold: double = 0.0295,  // min sensor reading above this → line lost (~0.025 on strip, ~0.030 on floor)
-    speed_sensitivity: double = 0.05,
+    speed_sensitivity: double = 0.1,
     turn_sensitivity: double = 0.01
 ) {
-
   timer sense_timer(0, dt)
   input sensor_reading: sensor_reading_t
   input key_cmd: int
 
   output sense: bool
-  output mode_change: bool
   output ctrl_cmd: control_command_t
 
-  state speed: double = 0.0
+  state speed: double = 0.30     // forward speed [0..1]
   state turn: double = 0.0
-  state auto_mode: bool = true
   state prev_error: double = 0.0
   state filtered_deriv: double = 0.0  // EMA-filtered derivative
   state search_dir: double = 1.0      // rotation direction when line is lost
 
-  initial mode Auto {
-    reaction(sense_timer) -> sense {=
-      lf_set(sense, true);
-    =}
+  reaction(sense_timer) -> sense {=
+    lf_set(sense, true);
+  =}
 
-    reaction(key_cmd) -> Manual, mode_change, ctrl_cmd {=
+  reaction(sensor_reading){=
+    printf("\rLag: " PRINTF_TIME " ms", (lf_time_physical() - lf_time_logical()) / MSEC(1));
+    printf("  LL:%.4f  L:%.4f  C:%.4f  R:%.4f  RR:%.4f",
+        sensor_reading->value.line_ll,sensor_reading->value.line_l, 
+        sensor_reading->value.line_c, 
+        sensor_reading->value.line_r, sensor_reading->value.line_rr);
+    fflush(stdout);
+  =}
+
+  initial mode Auto {
+    reaction(key_cmd) -> Manual, ctrl_cmd {=
       int key = key_cmd->value;
       if (key == 'Z') {
         self->speed = 0.0;
         self->turn  = 0.0;
       } else if (key == 'M') {
-        self->auto_mode = !self->auto_mode;
         lf_print("*** Manual mode ON");
-        lf_set(mode_change, self->auto_mode);
         // MuJoCo retains the last ctrl[] value — zero explicitly on mode switch.
         self->speed = 0.0;
         self->turn  = 0.0;
@@ -180,20 +176,14 @@ reactor Car(
         control_command_t stop = {.forward = 0.0, .turn = 0.0};
         lf_set(ctrl_cmd, stop);
         lf_set_mode(Manual);
+      } else if (key == 'U') {
+        self->speed += self->speed_sensitivity;
+      } else if (key == 'D') {
+        self->speed -= self->speed_sensitivity;
       }
     =}
 
     reaction(sensor_reading) -> ctrl_cmd {=
-      printf("\r" PRINTF_TIME, lf_time_logical_elapsed());
-      printf("  LL:%.4f  L:%.4f  C:%.4f  R:%.4f  RR:%.4f [%s]",
-          sensor_reading->value.line_ll,sensor_reading->value.line_l, 
-          sensor_reading->value.line_c, 
-          sensor_reading->value.line_r, sensor_reading->value.line_rr,
-          self->auto_mode ? "AUTO" : "MANUAL");
-      fflush(stdout);
-
-      if (!self->auto_mode) return;
-
       double rr = sensor_reading->value.line_rr;
       double r  = sensor_reading->value.line_r;
       double c  = sensor_reading->value.line_c;
@@ -206,13 +196,15 @@ reactor Car(
       if (r   < min_s) min_s = r;
       if (rr  < min_s) min_s = rr;
       if (min_s > self->lost_threshold) {
-        control_command_t cmd = {.forward = 0.0, .turn = self->search_dir * 0.2};
+        control_command_t cmd = {.forward = 0.3, .turn = self->search_dir * 0.2};
         lf_set(ctrl_cmd, cmd);
         return;
       }
 
       double total = ll + l + c + r + rr;
       double error = (-2*ll - l + r + 2*rr) / (total + 1e-6);
+
+      printf("  error:%.4f", error);
 
       // Keep search direction current while tracking.
       if      (error >  0.1) self->search_dir =  1.0;
@@ -221,7 +213,7 @@ reactor Car(
       // PD with EMA derivative (α=0.25 suppresses sensor noise amplified by 1/dt).
       double dt_s = (double)self->dt * 1e-9;
       double raw_deriv = (error - self->prev_error) / dt_s;
-      self->filtered_deriv = 0.25 * raw_deriv + 0.75 * self->filtered_deriv;
+      self->filtered_deriv = 0.1 * raw_deriv + 0.9 * self->filtered_deriv;
       self->prev_error = error;
 
       double ctrl_turn = self->kp * error + self->kd * self->filtered_deriv;
@@ -229,13 +221,15 @@ reactor Car(
       if (ctrl_turn < -1.0) ctrl_turn = -1.0;
 
       // Smooth speed reduction on curves; floor at min_speed.
-      double abs_error   = error < 0 ? -error : error;
-      double speed_scale = 1.0 / (1.0 + self->speed_kp * abs_error);
-      if (speed_scale < self->min_speed / self->auto_speed)
-          speed_scale = self->min_speed / self->auto_speed;
+      double sq_error   = error * error;
+      double speed_scale = 1.0 / (1.0 + self->speed_kp * sq_error);
+      if (speed_scale < self->min_speed / self->speed)
+          speed_scale = self->min_speed / self->speed;
+
+      printf("  speed_scale:%.4f", speed_scale);
 
       control_command_t cmd = {
-          .forward = self->auto_speed * speed_scale,
+          .forward = self->speed * speed_scale,
           .turn    = ctrl_turn
       };
       lf_set(ctrl_cmd, cmd);
@@ -243,19 +237,17 @@ reactor Car(
   }
 
   mode Manual {
-    reaction(key_cmd) -> ctrl_cmd, Auto, mode_change {=
+    reaction(key_cmd) -> ctrl_cmd, Auto {=
       int key = key_cmd->value;
       if (key == 'Z') {
         self->speed = 0.0;
         self->turn  = 0.0;
       } else if (key == 'M') {
-        self->auto_mode = !self->auto_mode;
         lf_print("*** Auto mode ON");
         self->speed = 0.0;
         self->turn  = 0.0;
-        lf_set(mode_change, self->auto_mode);
         lf_set_mode(Auto);
-      } else if (!self->auto_mode) {
+      } else {
         if      (key == 'U') self->speed += self->speed_sensitivity;
         else if (key == 'D') self->speed -= self->speed_sensitivity;
         else if (key == 'R') self->turn  -= self->turn_sensitivity;
@@ -264,17 +256,14 @@ reactor Car(
       control_command_t cmd = {.forward = self->speed, .turn = self->turn};
       lf_set(ctrl_cmd, cmd);
     =}
-
   }
-
 }
 
 main reactor {
-  m = new MuJoCuEnvSim()
-  c = new Car()
+  m = new MuJoCuCarWithTrack()
+  c = new Controller()
 
   c.sense -> m.sense
-  c.mode_change -> m.mode_change
   m.sensor_reading -> c.sensor_reading
   c.ctrl_cmd -> m.ctrl_cmd
 

--- a/src/CarLineFollow.lf
+++ b/src/CarLineFollow.lf
@@ -1,13 +1,16 @@
 /**
+ * @file CarLineFollow.lf
  * Line-following car on a figure-8 track in MuJoCo.
  *
- * Five downward rangefinders (ll, l, c, r, rr) feed a PID controller.
+ * Five downward rangefinders (ll, l, c, r, rr) feed a PD controller.
  * Sensor readings: ~0.025 m over track strip, ~0.030 m over bare floor.
  * Error = weighted lateral offset: (-2·ll - l + r + 2·rr) / (sum + ε)
  *   > 0 → drifted left  → turn right
  *   < 0 → drifted right → turn left
  *
  * Keys: M toggle auto/manual  ↑↓←→ manual drive  Backspace reset  Q quit
+ *
+ * See [README.md](../README.md) for prerequisites and installation instructions.
  *
  * @author Chadlia Jerad
  * @author Edward A. Lee
@@ -31,7 +34,11 @@ preamble {=
   } control_command_t;
 =}
 
-reactor MuJoCuCarWithTrack(
+/**
+ * MuJoCo simulator for the line-following car. Extends MuJoCoAuto with five line-sensor outputs
+ * and a control-command input so the Controller reactor can drive the car.
+ */
+reactor MuJoCoCarWithTrack(
     model_file: string = {= LF_SOURCE_GEN_DIRECTORY LF_FILE_SEPARATOR "car_line_follow.xml" =}
 ) extends MuJoCoAuto {
 
@@ -125,6 +132,10 @@ reactor MuJoCuCarWithTrack(
 }
 
 
+/**
+ * PD line-following controller with auto/manual modes. Reads five line sensors, computes
+ * a weighted lateral error, and outputs forward/turn commands. Press M to toggle modes.
+ */
 reactor Controller(
     kp: double = 1.0,
     kd: double = 0.1,
@@ -260,7 +271,7 @@ reactor Controller(
 }
 
 main reactor {
-  m = new MuJoCuCarWithTrack()
+  m = new MuJoCoCarWithTrack()
   c = new Controller()
 
   c.sense -> m.sense

--- a/src/CarLineFollow.lf
+++ b/src/CarLineFollow.lf
@@ -281,8 +281,7 @@ main reactor {
   reaction(startup) {=
     lf_print("*** Auto mode ON.  Press M to toggle manual / auto.");
     lf_print("*** Arrow keys: manual drive.  Backspace: reset.  Q: quit.\n");
-    lf_print("MuJoCo version number: %d\n", mj_version());
-  =}
+ =}
 
   reaction(m.key) -> m.restart, c.key_cmd {=
     if (m.key->value.act != GLFW_PRESS) return;

--- a/src/CarLineFollow.lf
+++ b/src/CarLineFollow.lf
@@ -255,7 +255,7 @@ reactor Controller(
         self->turn  = 0.0;
       } else if (key == 'M') {
         lf_print("*** Auto mode ON");
-        self->speed = 0.0;
+        self->speed = 0.30;
         self->turn  = 0.0;
         lf_set_mode(Auto);
       } else {

--- a/src/CarPlatoon.lf
+++ b/src/CarPlatoon.lf
@@ -1,12 +1,12 @@
 /**
  * Line-following platoon of three cars on a figure-8 track in MuJoCo.
  *
- * Cars a (lead), b (middle), c (rear) each run an independent PD line-following
- * controller.  Five downward rangefinders (ll, l, c, r, rr) feed each controller.
- * Sensor readings: ~0.025 m over track strip, ~0.030 m over bare floor.
- * Error = weighted lateral offset: (-2·ll - l + r + 2·rr) / (sum + ε)
+ * Each car runs a PD line-following controller with platoon gap control.
+ * Five line rangefinders (ll, l, c, r, rr): ~0.025 m on track, ~0.030 m on floor.
+ * Lateral error: (-2·ll - l + r + 2·rr) / (sum + ε)
+ * Front/rear rangefinders (cutoff 1.0 m) maintain spacing and trigger emergency stops.
  *
- * Keys: M toggle auto/manual  ↑↓←→ manual drive  Backspace reset  Q quit
+ * Keys: M auto/manual  ↑↓←→ manual drive  Backspace reset  Q quit
  *
  * @author Chadlia Jerad
  */
@@ -205,7 +205,6 @@ reactor Car(
       } else if (key == 'M') {
         self->auto_mode = !self->auto_mode;
         lf_set(mode_change, self->auto_mode);
-        // MuJoCo retains the last ctrl[] value — zero explicitly on mode switch.
         self->speed = 0.0;
         self->turn  = 0.0;
         self->filtered_deriv = 0.0;
@@ -238,7 +237,7 @@ reactor Car(
       double l  = sensor_reading->value.line_l;
       double ll = sensor_reading->value.line_ll;
 
-      // Lost-line detection: all sensors read ~0.030 m (floor); track strip gives ~0.025 m.
+      // Line lost when every sensor reads floor level (> lost_threshold).
       double min_s = ll < l ? ll : l;
       if (c  < min_s) min_s = c;
       if (r  < min_s) min_s = r;
@@ -255,7 +254,7 @@ reactor Car(
       if      (error >  0.1) self->search_dir =  1.0;
       else if (error < -0.1) self->search_dir = -1.0;
 
-      // PD with EMA derivative (α=0.25 suppresses sensor noise amplified by 1/dt).
+      // PD with EMA-filtered derivative (α=0.25).
       double dt_s = (double)self->dt * 1e-9;
       double raw_deriv = (error - self->prev_error) / dt_s;
       self->filtered_deriv = 0.25 * raw_deriv + 0.75 * self->filtered_deriv;
@@ -265,8 +264,7 @@ reactor Car(
       if (ctrl_turn >  1.0) ctrl_turn =  1.0;
       if (ctrl_turn < -1.0) ctrl_turn = -1.0;
 
-      // Gap-keeping: adjust target speed based on front/rear car distances.
-      // Rangefinder returns -1 when no surface hit within cutoff → ignore.
+      // Gap-keeping: rangefinder returns -1 when no car in range → skip.
       double target_speed = self->auto_speed;
       double dist_r = sensor_reading->value.dist_rear;
 
@@ -276,7 +274,7 @@ reactor Car(
         if (target_speed < 0.0)               target_speed = 0.0;
         if (target_speed > self->auto_speed)  target_speed = self->auto_speed;
       }
-      // If rear car is dangerously close, add a small defensive boost.
+      // Rear car too close: small defensive speed boost.
       if (dist_r >= 0.0 && dist_r < self->desired_gap * 0.5) {
         double boost = self->gap_kp * (self->desired_gap * 0.5 - dist_r);
         target_speed += boost;
@@ -323,7 +321,7 @@ reactor Car(
 
 main reactor {
   m  = new MuJoCuEnvSim()
-  c = new [3] Car()   // lead   — prefix a_; middle — prefix b_ ; rear   — prefix c_
+  c = new [3] Car()   // a_=lead, b_=middle, c_=rear
 
   c.sense -> m.sense
   m.sensor_reading -> c.sensor_reading
@@ -352,8 +350,10 @@ main reactor {
 
     if (cmd != 0) {
       lf_set(c[0].key_cmd, cmd);
-      lf_set(c[1].key_cmd, cmd);
-      lf_set(c[2].key_cmd, cmd);
+      if (cmd != 'M') {  // mode toggle only from lead car
+        lf_set(c[1].key_cmd, cmd);
+        lf_set(c[2].key_cmd, cmd);
+      }
     }
   =}
 

--- a/src/CarPlatoon.lf
+++ b/src/CarPlatoon.lf
@@ -36,6 +36,8 @@ preamble {=
     int line_c_address;
     int line_r_address;
     int line_rr_address;
+    int dist_front_address;
+    int dist_rear_address;
   } car_addresses_t;
 =}
 
@@ -54,11 +56,13 @@ reactor MuJoCuEnvSim(
 
   method read_sensors(i: int) : sensor_reading_t {=
     sensor_reading_t rs = {
-      .line_ll = self->context.d->sensordata[self->addrs[i].line_ll_address],
-      .line_l  = self->context.d->sensordata[self->addrs[i].line_l_address],
-      .line_c  = self->context.d->sensordata[self->addrs[i].line_c_address],
-      .line_r  = self->context.d->sensordata[self->addrs[i].line_r_address],
-      .line_rr = self->context.d->sensordata[self->addrs[i].line_rr_address],
+      .line_ll    = self->context.d->sensordata[self->addrs[i].line_ll_address],
+      .line_l     = self->context.d->sensordata[self->addrs[i].line_l_address],
+      .line_c     = self->context.d->sensordata[self->addrs[i].line_c_address],
+      .line_r     = self->context.d->sensordata[self->addrs[i].line_r_address],
+      .line_rr    = self->context.d->sensordata[self->addrs[i].line_rr_address],
+      .dist_front = self->context.d->sensordata[self->addrs[i].dist_front_address],
+      .dist_rear  = self->context.d->sensordata[self->addrs[i].dist_rear_address],
     };
     return rs;
   =}
@@ -93,6 +97,21 @@ reactor MuJoCuEnvSim(
           return;
         }
         *adr[s] = self->context.m->sensor_adr[idx];
+      }
+
+      static const char *dist_names[2] = {"dist_front", "dist_rear"};
+      int *dist_adr[2] = {
+        &self->addrs[i].dist_front_address, &self->addrs[i].dist_rear_address
+      };
+      for (int s = 0; s < 2; s++) {
+        snprintf(name, sizeof(name), "%s%s", prefixes[i], dist_names[s]);
+        int idx = mj_name2id(self->context.m, mjOBJ_SENSOR, name);
+        if (idx < 0 || self->context.m->sensor_dim[idx] != 1) {
+          lf_print_error("Car %d: bad sensor '%s'.", i, name);
+          lf_request_stop();
+          return;
+        }
+        *dist_adr[s] = self->context.m->sensor_adr[idx];
       }
     }
   =}
@@ -150,7 +169,11 @@ reactor Car(
     min_speed: double = 0.15,
     lost_threshold: double = 0.0295,  // min sensor reading above this → line lost
     speed_sensitivity: double = 0.05,
-    turn_sensitivity: double = 0.01
+    turn_sensitivity: double = 0.01,
+    desired_gap: double = 0.30,       // target gap to front car (m)
+    gap_kp: double = 0.5,             // proportional gain for gap control
+    stop_distance: double = 0.15,     // emergency stop when front car closer than this (m)
+    safe_distance: double = 0.22      // resume only when front car farther than this (m)
 ) {
 
   timer sense_timer(0, dt)
@@ -167,6 +190,7 @@ reactor Car(
   state prev_error: double = 0.0
   state filtered_deriv: double = 0.0  // EMA-filtered derivative
   state search_dir: double = 1.0      // rotation direction when line is lost
+  state emergency_stop: bool = false  // latched when front gap < stop_distance
 
   initial mode Auto {
     reaction(sense_timer) -> sense {=
@@ -193,6 +217,20 @@ reactor Car(
 
     reaction(sensor_reading) -> ctrl_cmd {=
       if (!self->auto_mode) return;
+
+      // Emergency stop: latch when front car too close; release with hysteresis.
+      double dist_f = sensor_reading->value.dist_front;
+      if (dist_f >= 0.0 && dist_f < self->stop_distance) {
+        self->emergency_stop = true;
+      } else if (self->emergency_stop && (dist_f < 0.0 || dist_f >= self->safe_distance)) {
+        self->emergency_stop = false;
+        self->filtered_deriv = 0.0;  // avoid derivative spike on resume
+      }
+      if (self->emergency_stop) {
+        control_command_t cmd = {.forward = 0.0, .turn = 0.0};
+        lf_set(ctrl_cmd, cmd);
+        return;
+      }
 
       double rr = sensor_reading->value.line_rr;
       double r  = sensor_reading->value.line_r;
@@ -227,14 +265,32 @@ reactor Car(
       if (ctrl_turn >  1.0) ctrl_turn =  1.0;
       if (ctrl_turn < -1.0) ctrl_turn = -1.0;
 
+      // Gap-keeping: adjust target speed based on front/rear car distances.
+      // Rangefinder returns -1 when no surface hit within cutoff → ignore.
+      double target_speed = self->auto_speed;
+      double dist_r = sensor_reading->value.dist_rear;
+
+      if (dist_f >= 0.0) {
+        double gap_error = dist_f - self->desired_gap;
+        target_speed += self->gap_kp * gap_error;
+        if (target_speed < 0.0)               target_speed = 0.0;
+        if (target_speed > self->auto_speed)  target_speed = self->auto_speed;
+      }
+      // If rear car is dangerously close, add a small defensive boost.
+      if (dist_r >= 0.0 && dist_r < self->desired_gap * 0.5) {
+        double boost = self->gap_kp * (self->desired_gap * 0.5 - dist_r);
+        target_speed += boost;
+        if (target_speed > self->auto_speed * 1.2) target_speed = self->auto_speed * 1.2;
+      }
+
       // Smooth speed reduction on curves; floor at min_speed.
       double abs_error   = error < 0 ? -error : error;
       double speed_scale = 1.0 / (1.0 + self->speed_kp * abs_error);
-      if (speed_scale < self->min_speed / self->auto_speed)
-          speed_scale = self->min_speed / self->auto_speed;
+      if (speed_scale < self->min_speed / target_speed)
+          speed_scale = self->min_speed / target_speed;
 
       control_command_t cmd = {
-          .forward = self->auto_speed * speed_scale,
+          .forward = target_speed * speed_scale,
           .turn    = ctrl_turn
       };
       lf_set(ctrl_cmd, cmd);

--- a/src/CarPlatoon.lf
+++ b/src/CarPlatoon.lf
@@ -1,0 +1,307 @@
+/**
+ * Line-following platoon of three cars on a figure-8 track in MuJoCo.
+ *
+ * Cars a (lead), b (middle), c (rear) each run an independent PD line-following
+ * controller.  Five downward rangefinders (ll, l, c, r, rr) feed each controller.
+ * Sensor readings: ~0.025 m over track strip, ~0.030 m over bare floor.
+ * Error = weighted lateral offset: (-2·ll - l + r + 2·rr) / (sum + ε)
+ *
+ * Keys: M toggle auto/manual  ↑↓←→ manual drive  Backspace reset  Q quit
+ *
+ * @author Chadlia Jerad
+ */
+target C {
+  keepalive: true,
+  files: ["models/car_platoon.xml", "models/track.xml", "models/car_sensor_rich.xml"]
+}
+
+import MuJoCoAuto from "lib/MuJoCoAuto.lf"
+
+preamble {=
+  typedef struct {
+    double line_ll, line_l, line_c, line_r, line_rr;
+    double dist_front, dist_rear;
+  } sensor_reading_t;
+
+  typedef struct {
+    double forward;   /* [0..1]  */
+    double turn;      /* [-1..1] */
+  } control_command_t;
+
+  typedef struct {
+    int forward_index;
+    int turn_index;
+    int line_ll_address;
+    int line_l_address;
+    int line_c_address;
+    int line_r_address;
+    int line_rr_address;
+  } car_addresses_t;
+=}
+
+reactor MuJoCuEnvSim(
+    model_file: string = {= LF_SOURCE_GEN_DIRECTORY LF_FILE_SEPARATOR "car_platoon.xml" =}
+) extends MuJoCoAuto {
+
+  input[3]  sense: bool
+  input mode_change: bool
+  output[3] sensor_reading: sensor_reading_t
+  input[3]  ctrl_cmd: control_command_t
+
+  state addrs: car_addresses_t[3] = {0}
+  state auto_mode: bool = true
+  state step_count: int = 0
+
+  method read_sensors(i: int) : sensor_reading_t {=
+    sensor_reading_t rs = {
+      .line_ll = self->context.d->sensordata[self->addrs[i].line_ll_address],
+      .line_l  = self->context.d->sensordata[self->addrs[i].line_l_address],
+      .line_c  = self->context.d->sensordata[self->addrs[i].line_c_address],
+      .line_r  = self->context.d->sensordata[self->addrs[i].line_r_address],
+      .line_rr = self->context.d->sensordata[self->addrs[i].line_rr_address],
+    };
+    return rs;
+  =}
+
+  reaction(startup) {=
+    static const char *prefixes[3]    = {"a_", "b_", "c_"};
+    static const char *line_names[5]  = {"line_ll", "line_l", "line_c", "line_r", "line_rr"};
+    char name[64];
+
+    for (int i = 0; i < 3; i++) {
+      snprintf(name, sizeof(name), "%sforward", prefixes[i]);
+      self->addrs[i].forward_index = mj_name2id(self->context.m, mjOBJ_ACTUATOR, name);
+      snprintf(name, sizeof(name), "%sturn", prefixes[i]);
+      self->addrs[i].turn_index = mj_name2id(self->context.m, mjOBJ_ACTUATOR, name);
+      if (self->addrs[i].forward_index < 0 || self->addrs[i].turn_index < 0) {
+        lf_print_error("Car %d: missing actuator (prefix '%s').", i, prefixes[i]);
+        lf_request_stop();
+        return;
+      }
+
+      int *adr[5] = {
+        &self->addrs[i].line_ll_address, &self->addrs[i].line_l_address,
+        &self->addrs[i].line_c_address,  &self->addrs[i].line_r_address,
+        &self->addrs[i].line_rr_address
+      };
+      for (int s = 0; s < 5; s++) {
+        snprintf(name, sizeof(name), "%s%s", prefixes[i], line_names[s]);
+        int idx = mj_name2id(self->context.m, mjOBJ_SENSOR, name);
+        if (idx < 0 || self->context.m->sensor_dim[idx] != 1) {
+          lf_print_error("Car %d: bad sensor '%s'.", i, name);
+          lf_request_stop();
+          return;
+        }
+        *adr[s] = self->context.m->sensor_adr[idx];
+      }
+    }
+  =}
+
+  reaction(restart) {=
+    for (int i = 0; i < 3; i++) {
+      self->context.d->ctrl[self->addrs[i].forward_index] = 0.0;
+      self->context.d->ctrl[self->addrs[i].turn_index]    = 0.0;
+    }
+  =}
+
+  reaction(physics_timer) {=
+    self->step_count++;
+    if (self->step_count % 1000 == 0) {
+      sensor_reading_t rs = read_sensors(0);
+      snprintf(self->text_to_overlay, OVERLAY_BUF_SIZE,
+               "Time=%6.1fs  a: LL:%.3f L:%.3f C:%.3f R:%.3f RR:%.3f [%s]",
+               lf_time_logical_elapsed() / 1e9,
+               rs.line_ll, rs.line_l, rs.line_c, rs.line_r, rs.line_rr,
+               self->auto_mode ? "AUTO" : "MANUAL");
+    }
+  =}
+
+  reaction(sense) -> sensor_reading {=
+    for (int i = 0; i < 3; i++) {
+      if (sense[i]->is_present) {
+        sensor_reading_t rs = read_sensors(i);
+        lf_set(sensor_reading[i], rs);
+      }
+    }
+  =}
+
+  reaction(ctrl_cmd) {=
+    for (int i = 0; i < 3; i++) {
+      if (ctrl_cmd[i]->is_present) {
+        self->context.d->ctrl[self->addrs[i].forward_index] = ctrl_cmd[i]->value.forward;
+        self->context.d->ctrl[self->addrs[i].turn_index]    = ctrl_cmd[i]->value.turn;
+      }
+    }
+  =}
+
+  reaction(mode_change) {=
+    self->auto_mode = mode_change->value;
+    lf_print("Mode: %s", self->auto_mode ? "AUTO" : "MANUAL");
+  =}
+}
+
+
+reactor Car(
+    auto_speed: double = 0.30,
+    kp: double = 2.0,
+    kd: double = 1.0,
+    dt: time = 50 ms,
+    speed_kp: double = 0.8,
+    min_speed: double = 0.15,
+    lost_threshold: double = 0.0295,  // min sensor reading above this → line lost
+    speed_sensitivity: double = 0.05,
+    turn_sensitivity: double = 0.01
+) {
+
+  timer sense_timer(0, dt)
+  input sensor_reading: sensor_reading_t
+  input key_cmd: int
+
+  output sense: bool
+  output mode_change: bool
+  output ctrl_cmd: control_command_t
+
+  state speed: double = 0.0
+  state turn: double = 0.0
+  state auto_mode: bool = true
+  state prev_error: double = 0.0
+  state filtered_deriv: double = 0.0  // EMA-filtered derivative
+  state search_dir: double = 1.0      // rotation direction when line is lost
+
+  initial mode Auto {
+    reaction(sense_timer) -> sense {=
+      lf_set(sense, true);
+    =}
+
+    reaction(key_cmd) -> Manual, mode_change, ctrl_cmd {=
+      int key = key_cmd->value;
+      if (key == 'Z') {
+        self->speed = 0.0;
+        self->turn  = 0.0;
+      } else if (key == 'M') {
+        self->auto_mode = !self->auto_mode;
+        lf_set(mode_change, self->auto_mode);
+        // MuJoCo retains the last ctrl[] value — zero explicitly on mode switch.
+        self->speed = 0.0;
+        self->turn  = 0.0;
+        self->filtered_deriv = 0.0;
+        control_command_t stop = {.forward = 0.0, .turn = 0.0};
+        lf_set(ctrl_cmd, stop);
+        lf_set_mode(Manual);
+      }
+    =}
+
+    reaction(sensor_reading) -> ctrl_cmd {=
+      if (!self->auto_mode) return;
+
+      double rr = sensor_reading->value.line_rr;
+      double r  = sensor_reading->value.line_r;
+      double c  = sensor_reading->value.line_c;
+      double l  = sensor_reading->value.line_l;
+      double ll = sensor_reading->value.line_ll;
+
+      // Lost-line detection: all sensors read ~0.030 m (floor); track strip gives ~0.025 m.
+      double min_s = ll < l ? ll : l;
+      if (c  < min_s) min_s = c;
+      if (r  < min_s) min_s = r;
+      if (rr < min_s) min_s = rr;
+      if (min_s > self->lost_threshold) {
+        control_command_t cmd = {.forward = 0.0, .turn = self->search_dir * 0.2};
+        lf_set(ctrl_cmd, cmd);
+        return;
+      }
+
+      double total = ll + l + c + r + rr;
+      double error = (-2*ll - l + r + 2*rr) / (total + 1e-6);
+
+      if      (error >  0.1) self->search_dir =  1.0;
+      else if (error < -0.1) self->search_dir = -1.0;
+
+      // PD with EMA derivative (α=0.25 suppresses sensor noise amplified by 1/dt).
+      double dt_s = (double)self->dt * 1e-9;
+      double raw_deriv = (error - self->prev_error) / dt_s;
+      self->filtered_deriv = 0.25 * raw_deriv + 0.75 * self->filtered_deriv;
+      self->prev_error = error;
+
+      double ctrl_turn = self->kp * error + self->kd * self->filtered_deriv;
+      if (ctrl_turn >  1.0) ctrl_turn =  1.0;
+      if (ctrl_turn < -1.0) ctrl_turn = -1.0;
+
+      // Smooth speed reduction on curves; floor at min_speed.
+      double abs_error   = error < 0 ? -error : error;
+      double speed_scale = 1.0 / (1.0 + self->speed_kp * abs_error);
+      if (speed_scale < self->min_speed / self->auto_speed)
+          speed_scale = self->min_speed / self->auto_speed;
+
+      control_command_t cmd = {
+          .forward = self->auto_speed * speed_scale,
+          .turn    = ctrl_turn
+      };
+      lf_set(ctrl_cmd, cmd);
+    =}
+  }
+
+  mode Manual {
+    reaction(key_cmd) -> ctrl_cmd, Auto, mode_change {=
+      int key = key_cmd->value;
+      if (key == 'Z') {
+        self->speed = 0.0;
+        self->turn  = 0.0;
+      } else if (key == 'M') {
+        self->auto_mode = !self->auto_mode;
+        self->speed = 0.0;
+        self->turn  = 0.0;
+        lf_set(mode_change, self->auto_mode);
+        lf_set_mode(Auto);
+      } else if (!self->auto_mode) {
+        if      (key == 'U') self->speed += self->speed_sensitivity;
+        else if (key == 'D') self->speed -= self->speed_sensitivity;
+        else if (key == 'R') self->turn  -= self->turn_sensitivity;
+        else if (key == 'L') self->turn  += self->turn_sensitivity;
+      }
+      control_command_t cmd = {.forward = self->speed, .turn = self->turn};
+      lf_set(ctrl_cmd, cmd);
+    =}
+  }
+}
+
+main reactor {
+  m  = new MuJoCuEnvSim()
+  c = new [3] Car()   // lead   — prefix a_; middle — prefix b_ ; rear   — prefix c_
+
+  c.sense -> m.sense
+  m.sensor_reading -> c.sensor_reading
+  c.ctrl_cmd -> m.ctrl_cmd
+
+  // c.mode_change -> m.mode_change   // lead car drives the mode overlay
+
+  reaction(startup) {=
+    lf_print("*** Auto mode ON.  Press M to toggle manual / auto.");
+    lf_print("*** Arrow keys: manual drive.  Backspace: reset.  Q: quit.\n");
+    lf_print("MuJoCo version number: %d\n", mj_version());
+  =}
+
+  reaction(m.key) -> m.restart, c.key_cmd {=
+    if (m.key->value.act != GLFW_PRESS) return;
+    int key = m.key->value.key;
+    int cmd = 0;
+
+    if      (key == GLFW_KEY_BACKSPACE) { lf_set(m.restart, true); cmd = 'Z'; }
+    else if (key == GLFW_KEY_Q)         { lf_request_stop(); }
+    else if (key == GLFW_KEY_M)         { cmd = 'M'; }
+    else if (key == GLFW_KEY_UP)        { cmd = 'U'; }
+    else if (key == GLFW_KEY_DOWN)      { cmd = 'D'; }
+    else if (key == GLFW_KEY_RIGHT)     { cmd = 'R'; }
+    else if (key == GLFW_KEY_LEFT)      { cmd = 'L'; }
+
+    if (cmd != 0) {
+      lf_set(c[0].key_cmd, cmd);
+      lf_set(c[1].key_cmd, cmd);
+      lf_set(c[2].key_cmd, cmd);
+    }
+  =}
+
+  reaction(shutdown) {=
+    lf_print("\nExiting.");
+  =}
+}

--- a/src/CarPlatoon.lf
+++ b/src/CarPlatoon.lf
@@ -159,17 +159,19 @@ reactor MuJoCoPlatoonWithTrack(
  * and a latching emergency stop on top of the base line-follow logic.
  */
 reactor Controller(
-    auto_speed: double = 0.30,
+    bank_index:int = 0, 
+    name: char[] = 'a', 
+    auto_speed: double = 0.35,
     kp: double = 1.0,
     kd: double = 0.1,
     dt: time = 50 ms,
     speed_kp: double = 2.0,
     min_speed: double = 0.15,
     lost_threshold: double = 0.0295,  // min sensor reading above this → line lost
-    speed_sensitivity: double = 0.1,
+    speed_sensitivity: double = 0.08,
     turn_sensitivity: double = 0.01,
-    desired_gap: double = 0.20,       // target gap to front car (m)
-    gap_kp: double = 0.5,             // proportional gain for gap control
+    desired_gap: double = 0.25,       // target gap to front car (m)
+    gap_kp: double = 0.6,             // proportional gain for gap control
     stop_distance: double = 0.15,     // emergency stop when front car closer than this (m)
     safe_distance: double = 0.22      // resume only when front car farther than this (m)
 ) {
@@ -188,6 +190,11 @@ reactor Controller(
   state search_dir: double = 1.0      // rotation direction when line is lost
   state emergency_stop: bool = false  // latched when front gap < stop_distance
 
+  reaction(startup) {=
+    self->speed = self->auto_speed;
+    lf_print("*** Car %c: Auto mode ON.", self->name);
+  =}
+
   reaction(sense_timer) -> sense {=
     lf_set(sense, true);
   =}
@@ -199,7 +206,7 @@ reactor Controller(
         self->speed = 0.0;
         self->turn  = 0.0;
       } else if (key == 'M') {
-        lf_print("*** Manual mode ON");
+        lf_print("*** Car %c: Manual mode ON.", self->name);
         // MuJoCo retains the last ctrl[] value — zero explicitly on mode switch.
         self->speed = 0.0;
         self->turn  = 0.0;
@@ -263,13 +270,13 @@ reactor Controller(
       if (ctrl_turn < -1.0) ctrl_turn = -1.0;
 
       // Gap-keeping: rangefinder returns -1 when no car in range → skip.
-      double target_speed = self->auto_speed;
+      double target_speed = self->speed;
 
       if (dist_f >= 0.0) {
         double gap_error = dist_f - self->desired_gap;
         target_speed += self->gap_kp * gap_error;
-        if (target_speed < 0.0)               target_speed = 0.0;
-        if (target_speed > self->auto_speed)  target_speed = self->auto_speed;
+        if (target_speed < 0.0)              target_speed = 0.0;
+        // if (target_speed > self->speed)      target_speed = self->speed * 1.2;
       }
 
       // Smooth speed reduction on curves; floor at min_speed.
@@ -293,7 +300,8 @@ reactor Controller(
         self->speed = 0.0;
         self->turn  = 0.0;
       } else if (key == 'M') {
-        self->speed = 0.0;
+        lf_print("*** Car %c: Auto mode ON.", self->name);
+        self->speed = self->auto_speed;
         self->turn  = 0.0;
         lf_set_mode(Auto);
       } else {
@@ -308,9 +316,11 @@ reactor Controller(
   }
 }
 
-main reactor {
+main reactor (
+  names: char[] = {'a', 'b', 'c'}
+){
   m  = new MuJoCoPlatoonWithTrack()
-  c = new [3] Controller()   // a_=lead, b_=middle, c_=rear
+  c = new [3] Controller(name = {= self->names[bank_index] =})   // a_=lead, b_=middle, c_=rear
 
   c.sense -> m.sense
   m.sensor_reading -> c.sensor_reading
@@ -319,7 +329,6 @@ main reactor {
   reaction(startup) {=
     lf_print("*** Auto mode ON.  Press M to toggle manual / auto.");
     lf_print("*** Arrow keys: manual drive.  Backspace: reset.  Q: quit.\n");
-    lf_print("MuJoCo version number: %d\n", mj_version());
   =}
 
   reaction(m.key) -> m.restart, c.key_cmd {=
@@ -337,10 +346,10 @@ main reactor {
 
     if (cmd != 0) {
       lf_set(c[0].key_cmd, cmd);
-      if (cmd != 'M') {  // mode toggle only from lead car
-        lf_set(c[1].key_cmd, cmd);
-        lf_set(c[2].key_cmd, cmd);
-      }
+      // if (cmd != 'M') {  // mode toggle only from lead car
+      //   lf_set(c[1].key_cmd, cmd);
+      //   lf_set(c[2].key_cmd, cmd);
+      // }
     }
   =}
 

--- a/src/CarPlatoon.lf
+++ b/src/CarPlatoon.lf
@@ -160,7 +160,7 @@ reactor MuJoCoPlatoonWithTrack(
  */
 reactor Controller(
     bank_index:int = 0, 
-    name: char[] = 'a', 
+    name: char = 'a', 
     auto_speed: double = 0.35,
     kp: double = 1.0,
     kd: double = 0.1,

--- a/src/CarPlatoon.lf
+++ b/src/CarPlatoon.lf
@@ -165,15 +165,15 @@ reactor Controller(
     kp: double = 1.0,
     kd: double = 0.1,
     dt: time = 50 ms,
-    speed_kp: double = 2.0,
+    speed_kp: double = 1.5,
     min_speed: double = 0.15,
     lost_threshold: double = 0.0295,  // min sensor reading above this → line lost
     speed_sensitivity: double = 0.08,
     turn_sensitivity: double = 0.01,
-    desired_gap: double = 0.25,       // target gap to front car (m)
+    desired_gap: double = 0.15,       // target gap to front car (m)
     gap_kp: double = 0.6,             // proportional gain for gap control
-    stop_distance: double = 0.15,     // emergency stop when front car closer than this (m)
-    safe_distance: double = 0.22      // resume only when front car farther than this (m)
+    stop_distance: double = 0.07,     // emergency stop when front car closer than this (m)
+    safe_distance: double = 0.2      // resume only when front car farther than this (m)
 ) {
 
   timer sense_timer(0, dt)
@@ -189,6 +189,7 @@ reactor Controller(
   state filtered_deriv: double = 0.0  // EMA-filtered derivative
   state search_dir: double = 1.0      // rotation direction when line is lost
   state emergency_stop: bool = false  // latched when front gap < stop_distance
+  state counter: int = 0
 
   reaction(startup) {=
     self->speed = self->auto_speed;
@@ -289,6 +290,9 @@ reactor Controller(
           .forward = target_speed * speed_scale,
           .turn    = ctrl_turn
       };
+      self->counter++;
+      if (self->counter % 80)
+        lf_print("*** Car %c: error=%.3f, dist_f=%.3f, speed=%.3f, turn=%.3f", self->name, error, dist_f, cmd.forward, cmd.turn);
       lf_set(ctrl_cmd, cmd);
     =}
   }
@@ -320,7 +324,7 @@ main reactor (
   names: char[] = {'a', 'b', 'c'}
 ){
   m  = new MuJoCoPlatoonWithTrack()
-  c = new [3] Controller(name = {= self->names[bank_index] =})   // a_=lead, b_=middle, c_=rear
+  c = new [3] Controller(name = {= self->names[bank_index] =})   // a_=lead, b_=middle, c_=lead
 
   c.sense -> m.sense
   m.sensor_reading -> c.sensor_reading

--- a/src/CarPlatoon.lf
+++ b/src/CarPlatoon.lf
@@ -1,4 +1,5 @@
 /**
+ * @file CarPlatoon.lf
  * Line-following platoon of three cars on a figure-8 track in MuJoCo.
  *
  * Each car runs a PD line-following controller with platoon gap control.
@@ -8,9 +9,13 @@
  *
  * Keys: M auto/manual  ↑↓←→ manual drive  Backspace reset  Q quit
  *
+ * See [README.md](../README.md) for prerequisites and installation instructions.
+ *
  * @author Chadlia Jerad
+ * @author Edward A. Lee
  */
 target C {
+  workers: 1,  // For macOS, all GLFW operations must be done on the main thread.
   keepalive: true,
   files: ["models/car_platoon.xml", "models/track.xml", "models/car_sensor_rich.xml"]
 }
@@ -41,17 +46,19 @@ preamble {=
   } car_addresses_t;
 =}
 
-reactor MuJoCuEnvSim(
+/**
+ * MuJoCo simulator for three-car platoon. Wraps MuJoCoAuto with per-car sensor outputs
+ * and control-command inputs, using prefixed actuator/sensor names (a_, b_, c_).
+ */
+reactor MuJoCoPlatoonWithTrack(
     model_file: string = {= LF_SOURCE_GEN_DIRECTORY LF_FILE_SEPARATOR "car_platoon.xml" =}
 ) extends MuJoCoAuto {
 
   input[3]  sense: bool
-  input mode_change: bool
   output[3] sensor_reading: sensor_reading_t
   input[3]  ctrl_cmd: control_command_t
 
   state addrs: car_addresses_t[3] = {0}
-  state auto_mode: bool = true
   state step_count: int = 0
 
   method read_sensors(i: int) : sensor_reading_t {=
@@ -114,6 +121,8 @@ reactor MuJoCuEnvSim(
         *dist_adr[s] = self->context.m->sensor_adr[idx];
       }
     }
+    snprintf(self->text_to_overlay, OVERLAY_BUF_SIZE,
+               "Car Platooning Demo.");
   =}
 
   reaction(restart) {=
@@ -125,14 +134,6 @@ reactor MuJoCuEnvSim(
 
   reaction(physics_timer) {=
     self->step_count++;
-    if (self->step_count % 1000 == 0) {
-      sensor_reading_t rs = read_sensors(0);
-      snprintf(self->text_to_overlay, OVERLAY_BUF_SIZE,
-               "Time=%6.1fs  a: LL:%.3f L:%.3f C:%.3f R:%.3f RR:%.3f [%s]",
-               lf_time_logical_elapsed() / 1e9,
-               rs.line_ll, rs.line_l, rs.line_c, rs.line_r, rs.line_rr,
-               self->auto_mode ? "AUTO" : "MANUAL");
-    }
   =}
 
   reaction(sense) -> sensor_reading {=
@@ -152,25 +153,24 @@ reactor MuJoCuEnvSim(
       }
     }
   =}
-
-  reaction(mode_change) {=
-    self->auto_mode = mode_change->value;
-    lf_print("Mode: %s", self->auto_mode ? "AUTO" : "MANUAL");
-  =}
 }
 
 
-reactor Car(
+/**
+ * PD line-following controller for one platoon member. Adds gap-keeping (front/rear rangefinders)
+ * and a latching emergency stop on top of the base line-follow logic.
+ */
+reactor Controller(
     auto_speed: double = 0.30,
-    kp: double = 2.0,
-    kd: double = 1.0,
+    kp: double = 1.0,
+    kd: double = 0.1,
     dt: time = 50 ms,
-    speed_kp: double = 0.8,
+    speed_kp: double = 2.0,
     min_speed: double = 0.15,
     lost_threshold: double = 0.0295,  // min sensor reading above this → line lost
-    speed_sensitivity: double = 0.05,
+    speed_sensitivity: double = 0.1,
     turn_sensitivity: double = 0.01,
-    desired_gap: double = 0.30,       // target gap to front car (m)
+    desired_gap: double = 0.20,       // target gap to front car (m)
     gap_kp: double = 0.5,             // proportional gain for gap control
     stop_distance: double = 0.15,     // emergency stop when front car closer than this (m)
     safe_distance: double = 0.22      // resume only when front car farther than this (m)
@@ -181,42 +181,42 @@ reactor Car(
   input key_cmd: int
 
   output sense: bool
-  output mode_change: bool
   output ctrl_cmd: control_command_t
 
-  state speed: double = 0.0
+  state speed: double = 0.30
   state turn: double = 0.0
-  state auto_mode: bool = true
   state prev_error: double = 0.0
   state filtered_deriv: double = 0.0  // EMA-filtered derivative
   state search_dir: double = 1.0      // rotation direction when line is lost
   state emergency_stop: bool = false  // latched when front gap < stop_distance
 
-  initial mode Auto {
-    reaction(sense_timer) -> sense {=
-      lf_set(sense, true);
-    =}
+  reaction(sense_timer) -> sense {=
+    lf_set(sense, true);
+  =}
 
-    reaction(key_cmd) -> Manual, mode_change, ctrl_cmd {=
+  initial mode Auto {
+    reaction(key_cmd) -> Manual, ctrl_cmd {=
       int key = key_cmd->value;
       if (key == 'Z') {
         self->speed = 0.0;
         self->turn  = 0.0;
       } else if (key == 'M') {
-        self->auto_mode = !self->auto_mode;
-        lf_set(mode_change, self->auto_mode);
+        lf_print("*** Manual mode ON");
+        // MuJoCo retains the last ctrl[] value — zero explicitly on mode switch.
         self->speed = 0.0;
         self->turn  = 0.0;
         self->filtered_deriv = 0.0;
         control_command_t stop = {.forward = 0.0, .turn = 0.0};
         lf_set(ctrl_cmd, stop);
         lf_set_mode(Manual);
+      } else if (key == 'U') {
+        self->speed += self->speed_sensitivity;
+      } else if (key == 'D') {
+        self->speed -= self->speed_sensitivity;
       }
     =}
 
     reaction(sensor_reading) -> ctrl_cmd {=
-      if (!self->auto_mode) return;
-
       // Emergency stop: latch when front car too close; release with hysteresis.
       double dist_f = sensor_reading->value.dist_front;
       if (dist_f >= 0.0 && dist_f < self->stop_distance) {
@@ -296,18 +296,16 @@ reactor Car(
   }
 
   mode Manual {
-    reaction(key_cmd) -> ctrl_cmd, Auto, mode_change {=
+    reaction(key_cmd) -> ctrl_cmd, Auto {=
       int key = key_cmd->value;
       if (key == 'Z') {
         self->speed = 0.0;
         self->turn  = 0.0;
       } else if (key == 'M') {
-        self->auto_mode = !self->auto_mode;
         self->speed = 0.0;
         self->turn  = 0.0;
-        lf_set(mode_change, self->auto_mode);
         lf_set_mode(Auto);
-      } else if (!self->auto_mode) {
+      } else {
         if      (key == 'U') self->speed += self->speed_sensitivity;
         else if (key == 'D') self->speed -= self->speed_sensitivity;
         else if (key == 'R') self->turn  -= self->turn_sensitivity;
@@ -320,14 +318,12 @@ reactor Car(
 }
 
 main reactor {
-  m  = new MuJoCuEnvSim()
-  c = new [3] Car()   // a_=lead, b_=middle, c_=rear
+  m  = new MuJoCoPlatoonWithTrack()
+  c = new [3] Controller()   // a_=lead, b_=middle, c_=rear
 
   c.sense -> m.sense
   m.sensor_reading -> c.sensor_reading
   c.ctrl_cmd -> m.ctrl_cmd
-
-  // c.mode_change -> m.mode_change   // lead car drives the mode overlay
 
   reaction(startup) {=
     lf_print("*** Auto mode ON.  Press M to toggle manual / auto.");

--- a/src/CarPlatoon.lf
+++ b/src/CarPlatoon.lf
@@ -25,7 +25,7 @@ import MuJoCoAuto from "lib/MuJoCoAuto.lf"
 preamble {=
   typedef struct {
     double line_ll, line_l, line_c, line_r, line_rr;
-    double dist_front, dist_rear;
+    double dist_front;
   } sensor_reading_t;
 
   typedef struct {
@@ -42,7 +42,6 @@ preamble {=
     int line_r_address;
     int line_rr_address;
     int dist_front_address;
-    int dist_rear_address;
   } car_addresses_t;
 =}
 
@@ -69,7 +68,6 @@ reactor MuJoCoPlatoonWithTrack(
       .line_r     = self->context.d->sensordata[self->addrs[i].line_r_address],
       .line_rr    = self->context.d->sensordata[self->addrs[i].line_rr_address],
       .dist_front = self->context.d->sensordata[self->addrs[i].dist_front_address],
-      .dist_rear  = self->context.d->sensordata[self->addrs[i].dist_rear_address],
     };
     return rs;
   =}
@@ -106,11 +104,11 @@ reactor MuJoCoPlatoonWithTrack(
         *adr[s] = self->context.m->sensor_adr[idx];
       }
 
-      static const char *dist_names[2] = {"dist_front", "dist_rear"};
-      int *dist_adr[2] = {
-        &self->addrs[i].dist_front_address, &self->addrs[i].dist_rear_address
+      static const char *dist_names[1] = {"dist_front"};
+      int *dist_adr[1] = {
+        &self->addrs[i].dist_front_address
       };
-      for (int s = 0; s < 2; s++) {
+      for (int s = 0; s < 1; s++) {
         snprintf(name, sizeof(name), "%s%s", prefixes[i], dist_names[s]);
         int idx = mj_name2id(self->context.m, mjOBJ_SENSOR, name);
         if (idx < 0 || self->context.m->sensor_dim[idx] != 1) {
@@ -266,19 +264,12 @@ reactor Controller(
 
       // Gap-keeping: rangefinder returns -1 when no car in range → skip.
       double target_speed = self->auto_speed;
-      double dist_r = sensor_reading->value.dist_rear;
 
       if (dist_f >= 0.0) {
         double gap_error = dist_f - self->desired_gap;
         target_speed += self->gap_kp * gap_error;
         if (target_speed < 0.0)               target_speed = 0.0;
         if (target_speed > self->auto_speed)  target_speed = self->auto_speed;
-      }
-      // Rear car too close: small defensive speed boost.
-      if (dist_r >= 0.0 && dist_r < self->desired_gap * 0.5) {
-        double boost = self->gap_kp * (self->desired_gap * 0.5 - dist_r);
-        target_speed += boost;
-        if (target_speed > self->auto_speed * 1.2) target_speed = self->auto_speed * 1.2;
       }
 
       // Smooth speed reduction on curves; floor at min_speed.

--- a/src/models/car_line_follow.xml
+++ b/src/models/car_line_follow.xml
@@ -1,0 +1,62 @@
+<mujoco>
+  <!--
+    car_line_follow.xml — single-car line-following environment.
+    Composes track.xml with car_sensor_rich.xml via <attach prefix="car_">.
+    All sensor/actuator names are prefixed: car_forward, car_turn, car_line_ll, …
+    Note: <attach> does not copy <default> classes, so wheel/decor/dist_sensor
+    are redeclared here.
+  -->
+
+  <compiler autolimits="true"/>
+  <option timestep="0.001"/>
+  <option integrator="implicitfast"/>
+
+  <visual>
+    <headlight ambient=".6 .6 .6" diffuse=".8 .8 .8" specular="0 0 0"/>
+  </visual>
+
+  <asset>
+    <texture name="grid" type="2d" builtin="checker" width="512" height="512"
+             rgb1=".65 .65 .65" rgb2=".80 .80 .80"/>
+    <material name="grid" texture="grid" texrepeat="1 1" texuniform="true" reflectance=".4"/>
+
+    <model name="car" file="car_sensor_rich.xml"/>
+  </asset>
+
+  <default>
+    <joint damping=".03" actuatorfrcrange="-0.5 0.5"/>
+    <default class="wheel">
+      <geom type="cylinder" size=".03 .01" rgba=".5 .5 1 1"/>
+    </default>
+    <default class="decor">
+      <site type="box" rgba=".5 1 .5 1"/>
+    </default>
+    <default class="dist_sensor">
+      <site type="sphere" size=".004" rgba="1 .3 .3 1"/>
+    </default>
+    <!--
+      Track geoms are non-collidable (contype/conaffinity=0) so the car passes over them
+      without bumping. mj_ray (used by rangefinder sensors) ignores collision filtering,
+      so the sensors still detect these geoms.
+    -->
+    <default class="track">
+      <geom type="box" rgba="0.05 0.05 0.05 1" contype="0" conaffinity="0"/>
+    </default>
+  </default>
+
+  <worldbody>
+    <include file="track.xml"/>
+
+    <!-- Fixed overhead lights — illuminate the full figure-8 track evenly -->
+    <light name="overhead center" pos=" 0    0   2.0" dir="0 0 -1" diffuse=".1 .1 .1" specular="0 0 0"/>
+    <light name="overhead right"  pos=" 0.6  0   1.5" dir="0 0 -1" diffuse=".1 .1 .1" specular="0 0 0"/>
+    <light name="overhead left"   pos="-0.6  0   1.5" dir="0 0 -1" diffuse=".1 .1 .1" specular="0 0 0"/>
+
+    <!-- Car body on the top-right straight, facing +x -->
+    <frame name="car_frame" pos="0.9 0.6 0.03">
+      <attach model="car" body="car" prefix="car_"/>
+    </frame>
+  </worldbody>
+
+
+</mujoco>

--- a/src/models/car_line_follow.xml
+++ b/src/models/car_line_follow.xml
@@ -20,6 +20,7 @@
              rgb1=".65 .65 .65" rgb2=".80 .80 .80"/>
     <material name="grid" texture="grid" texrepeat="1 1" texuniform="true" reflectance=".4"/>
 
+    <material name="car_body" rgba="0.7 0.7 0.7 1"/>
     <model name="car" file="car_sensor_rich.xml"/>
   </asset>
 

--- a/src/models/car_platoon.xml
+++ b/src/models/car_platoon.xml
@@ -1,0 +1,83 @@
+<mujoco>
+  <!--
+    car_platoon.xml — three-car platoon on the figure-8 track.
+    Composes track.xml with three instances of car_sensor_rich.xml via <attach>.
+
+    Prefixed names per car (prefix a_, b_, c_):
+      Actuators : a_forward  a_turn   b_forward  b_turn   c_forward  c_turn
+      Sensors   : a_line_ll … a_line_rr  a_dist_front  a_dist_rear  (same for b_, c_)
+      Body color: a_body (red)  b_body (green)  c_body (blue)
+
+    Note: <attach> does not copy <default> classes; wheel/decor/dist_sensor are
+    redeclared here. The "body" material must be provided by the parent (this file)
+    with the per-car prefix because car_sensor_rich.xml references it externally.
+
+    Platoon order on the top-right straight (y=0.6, z=0.03), facing +x:
+      car_a (lead)   x = 0.9
+      car_b (middle) x = 0.6
+      car_c (rear)   x = 0.3
+  -->
+
+  <compiler autolimits="true"/>
+  <option timestep="0.001"/>
+  <option integrator="implicitfast"/>
+
+  <visual>
+    <headlight ambient=".6 .6 .6" diffuse=".8 .8 .8" specular="0 0 0"/>
+  </visual>
+
+  <asset>
+    <texture name="grid" type="2d" builtin="checker" width="512" height="512"
+             rgb1=".65 .65 .65" rgb2=".80 .80 .80"/>
+    <material name="grid" texture="grid" texrepeat="1 1" texuniform="true" reflectance=".4"/>
+
+    <!-- Per-car chassis colors; each becomes <prefix>body after <attach>. -->
+    <material name="a_body" rgba="0.85 0.25 0.20 1"/>  <!-- red   — lead   -->
+    <material name="b_body" rgba="0.20 0.70 0.25 1"/>  <!-- green — middle -->
+    <material name="c_body" rgba="0.20 0.45 0.90 1"/>  <!-- blue  — rear   -->
+
+    <model name="car" file="car_sensor_rich.xml"/>
+  </asset>
+
+  <default>
+    <joint damping=".03" actuatorfrcrange="-0.5 0.5"/>
+    <default class="wheel">
+      <geom type="cylinder" size=".03 .01" rgba=".5 .5 1 1"/>
+    </default>
+    <default class="decor">
+      <site type="box" rgba=".5 1 .5 1"/>
+    </default>
+    <default class="dist_sensor">
+      <site type="sphere" size=".004" rgba="1 .3 .3 1"/>
+    </default>
+    <!-- Non-collidable track geoms; mj_ray still detects them for rangefinders. -->
+    <default class="track">
+      <geom type="box" rgba="0.05 0.05 0.05 1" contype="0" conaffinity="0"/>
+    </default>
+  </default>
+
+  <worldbody>
+    <include file="track.xml"/>
+
+    <light name="overhead center" pos=" 0    0   2.0" dir="0 0 -1" diffuse=".1 .1 .1" specular="0 0 0"/>
+    <light name="overhead right"  pos=" 0.6  0   1.5" dir="0 0 -1" diffuse=".1 .1 .1" specular="0 0 0"/>
+    <light name="overhead left"   pos="-0.6  0   1.5" dir="0 0 -1" diffuse=".1 .1 .1" specular="0 0 0"/>
+
+    <!-- Lead car (red) -->
+    <frame name="car_a_frame" pos="0.9 0.6 0.03">
+      <attach model="car" body="car" prefix="a_"/>
+    </frame>
+
+    <!-- Middle car (green) -->
+    <frame name="car_b_frame" pos="0.6 0.6 0.03">
+      <attach model="car" body="car" prefix="b_"/>
+    </frame>
+
+    <!-- Rear car (blue) -->
+    <frame name="car_c_frame" pos="0.3 0.6 0.03">
+      <attach model="car" body="car" prefix="c_"/>
+    </frame>
+
+  </worldbody>
+
+</mujoco>

--- a/src/models/car_sensor_rich.xml
+++ b/src/models/car_sensor_rich.xml
@@ -1,0 +1,102 @@
+<!--
+  car_sensor_rich.xml — car body with 5 line sensors and 2 distance sensors.
+  Used via <attach> in a parent model (e.g. car_line_follow.xml, carPlatoon.xml).
+  Provides: chasis mesh, freejoint body, tendon/actuator (forward/turn),
+    rangefinders line_ll/l/c/r/rr (cutoff 0.05 m) and dist_front/rear (cutoff 1.0 m).
+  The parent must declare the track default class and ground plane.
+-->
+<mujoco model="carSensorRich">
+  <compiler autolimits="true"/>
+
+  <asset>
+    <mesh name="chasis" scale=".01 .006 .0015"
+      vertex=" 9   2   0
+              -10  10  10
+               9  -2   0
+               10  3  -10
+               10 -3  -10
+              -8   10 -10
+              -10 -10  10
+              -8  -10 -10
+              -5   0   20"/>
+  </asset>
+
+  <default>
+    <joint damping=".03" actuatorfrcrange="-0.5 0.5"/>
+    <default class="wheel">
+      <geom type="cylinder" size=".03 .01" rgba=".5 .5 1 1"/>
+    </default>
+    <default class="decor">
+      <site type="box" rgba=".5 1 .5 1"/>
+    </default>
+    <default class="dist_sensor">
+      <site type="sphere" size=".004" rgba="1 .3 .3 1"/>
+    </default>
+  </default>
+
+  <worldbody>
+    <body name="car" pos="0 0 0">
+      <freejoint/>
+      <light name="top light" pos="0 0 2" mode="trackcom" diffuse=".25 .25 .25"/>
+      <geom name="chasis" type="mesh" mesh="chasis"/>
+      <!-- front wheel: raise radius to match rear -->
+      <geom name="front wheel" pos=".08 0 -.005" type="sphere" size=".025" condim="1" priority="1"/>
+      <light name="front light" pos=".1 0 .02" dir="2 0 -1" diffuse="1 1 1"/>
+
+      <body name="left wheel" pos="-.07 .06 0" zaxis="0 1 0">
+        <joint name="left"/>
+        <geom class="wheel"/>
+        <site class="decor" size=".006 .025 .012"/>
+        <site class="decor" size=".025 .006 .012"/>
+      </body>
+      <body name="right wheel" pos="-.07 -.06 0" zaxis="0 1 0">
+        <joint name="right"/>
+        <geom class="wheel"/>
+        <site class="decor" size=".006 .025 .012"/>
+        <site class="decor" size=".025 .006 .012"/>
+      </body>
+
+      <!-- 5 line sensors at ±10 mm and ±25 mm; euler "180 0 0" aims z toward floor -->
+      <site name="line_ll_site" pos=".08  .025 0" euler="180 0 0"/>
+      <site name="line_l_site"  pos=".08  .010 0" euler="180 0 0"/>
+      <site name="line_c_site"  pos=".08  .000 0" euler="180 0 0"/>
+      <site name="line_r_site"  pos=".08 -.010 0" euler="180 0 0"/>
+      <site name="line_rr_site" pos=".08 -.025 0" euler="180 0 0"/>
+
+      <!-- Distance sensors: euler "0 ±90 0" aligns site z with car ±x -->
+      <site name="dist_front_site" class="dist_sensor"
+            pos=".11  0  .01" euler="0 -90 0"/>
+      <site name="dist_rear_site"  class="dist_sensor"
+            pos="-.11 0  .01" euler="0  90 0"/>
+    </body>
+  </worldbody>
+
+  <tendon>
+    <fixed name="forward">
+      <joint joint="left"  coef=".5"/>
+      <joint joint="right" coef=".5"/>
+    </fixed>
+    <fixed name="turn">
+      <joint joint="left"  coef="-.5"/>
+      <joint joint="right" coef=".5"/>
+    </fixed>
+  </tendon>
+
+  <actuator>
+    <motor name="forward" tendon="forward" ctrlrange="-1 1"/>
+    <motor name="turn"    tendon="turn"    ctrlrange="-1 1"/>
+  </actuator>
+
+  <sensor>
+    <!-- cutoff 0.05 m: above bare-floor reading (~0.030 m); -1 if ray misses all surfaces -->
+    <rangefinder name="line_ll" site="line_ll_site" cutoff="0.05"/>
+    <rangefinder name="line_l"  site="line_l_site"  cutoff="0.05"/>
+    <rangefinder name="line_c"  site="line_c_site"  cutoff="0.05"/>
+    <rangefinder name="line_r"  site="line_r_site"  cutoff="0.05"/>
+    <rangefinder name="line_rr" site="line_rr_site" cutoff="0.05"/>
+    <!-- cutoff 1.0 m: suitable for platoon spacing (~0.3 m gaps) -->
+    <rangefinder name="dist_front" site="dist_front_site" cutoff="1.0"/>
+    <rangefinder name="dist_rear"  site="dist_rear_site"  cutoff="1.0"/>
+  </sensor>
+
+</mujoco>

--- a/src/models/car_sensor_rich.xml
+++ b/src/models/car_sensor_rich.xml
@@ -38,7 +38,7 @@
     <body name="car" pos="0 0 0">
       <freejoint/>
       <light name="top light" pos="0 0 2" mode="trackcom" diffuse=".25 .25 .25"/>
-      <geom name="chasis" type="mesh" mesh="chasis"/>
+      <geom name="chasis" type="mesh" mesh="chasis" material="body"/>
       <!-- front wheel: raise radius to match rear -->
       <geom name="front wheel" pos=".08 0 -.005" type="sphere" size=".025" condim="1" priority="1"/>
       <light name="front light" pos=".1 0 .02" dir="2 0 -1" diffuse="1 1 1"/>

--- a/src/models/car_sensor_rich.xml
+++ b/src/models/car_sensor_rich.xml
@@ -1,8 +1,8 @@
 <!--
-  car_sensor_rich.xml — car body with 5 line sensors and 2 distance sensors.
-  Used via <attach> in a parent model (e.g. car_line_follow.xml, carPlatoon.xml).
+  car_sensor_rich.xml — car body with 5 line sensors and 1 front distance sensor.
+  Used via <attach> in a parent model (e.g. car_line_follow.xml, car_platoon.xml).
   Provides: chasis mesh, freejoint body, tendon/actuator (forward/turn),
-    rangefinders line_ll/l/c/r/rr (cutoff 0.05 m) and dist_front/rear (cutoff 1.0 m).
+    rangefinders line_ll/l/c/r/rr (cutoff 0.05 m) and dist_front (cutoff 1.0 m).
   The parent must declare the track default class and ground plane.
 -->
 <mujoco model="carSensorRich">
@@ -63,11 +63,9 @@
       <site name="line_r_site"  pos=".08 -.010 0" euler="180 0 0"/>
       <site name="line_rr_site" pos=".08 -.025 0" euler="180 0 0"/>
 
-      <!-- Distance sensors: euler "0 ±90 0" aligns site z with car ±x -->
+      <!-- Front distance sensor: euler "0 -90 0" aligns site z with car +x -->
       <site name="dist_front_site" class="dist_sensor"
             pos=".11  0  .01" euler="0 -90 0"/>
-      <site name="dist_rear_site"  class="dist_sensor"
-            pos="-.11 0  .01" euler="0  90 0"/>
     </body>
   </worldbody>
 
@@ -96,7 +94,6 @@
     <rangefinder name="line_rr" site="line_rr_site" cutoff="0.05"/>
     <!-- cutoff 1.0 m: suitable for platoon spacing (~0.3 m gaps) -->
     <rangefinder name="dist_front" site="dist_front_site" cutoff="1.0"/>
-    <rangefinder name="dist_rear"  site="dist_rear_site"  cutoff="1.0"/>
   </sensor>
 
 </mujoco>

--- a/src/models/car_sensor_rich.xml
+++ b/src/models/car_sensor_rich.xml
@@ -63,9 +63,9 @@
       <site name="line_r_site"  pos=".08 -.010 0" euler="180 0 0"/>
       <site name="line_rr_site" pos=".08 -.025 0" euler="180 0 0"/>
 
-      <!-- Front distance sensor: euler "0 -90 0" aligns site z with car +x -->
+      <!-- Front distance sensor: euler "0 90 0" aligns site z with car +x -->
       <site name="dist_front_site" class="dist_sensor"
-            pos=".11  0  .01" euler="0 -90 0"/>
+            pos=".11  0  .01" euler="0 90 0"/>
     </body>
   </worldbody>
 

--- a/src/models/track.xml
+++ b/src/models/track.xml
@@ -1,0 +1,61 @@
+<!--
+  track.xml — figure-8 track, 1.5x scale, 45-deg chamfered corners, connected crossing.
+  Designed to be <include>-d inside a <worldbody> block.
+  Requires the parent model to declare:
+    <default class="track">
+      <geom type="box" rgba="0.05 0.05 0.05 1" contype="0" conaffinity="0"/>
+    </default>
+
+  Layout
+  ──────
+  Right loop : x in [0.15, 1.65]  y in [-0.60, 0.60]
+  Left  loop : x in [-1.65, -0.15]  y in [-0.60, 0.60]
+  Crossing X : diagonals from (±0.15, ∓0.60) through origin
+  Corners    : 45-deg chamfer size=0.090 m
+  Strip      : half-width=0.018 m  half-height=0.0025 m
+
+  Car spawn hint: pos="0.86 0.60 0.03"
+-->
+
+<mujocoinclude>
+  <!-- Ground plane -->
+  <geom type="plane" size="4 4 .01" material="grid"/>
+
+  <!-- ── Right loop ── -->
+  <!-- top straight: x_inner → x_outer-chamfer -->
+  <geom class="track" pos="0.8550 0.6000 0.0025" size="0.7050 0.018 0.0025"/>
+  <!-- bottom straight -->
+  <geom class="track" pos="0.8550 -0.6000 0.0025" size="0.7050 0.018 0.0025"/>
+  <!-- right side: y_bot+chamfer → y_top-chamfer -->
+  <geom class="track" pos="1.6500 0.0000 0.0025" size="0.018 0.5100 0.0025"/>
+  <!-- corner TR: 45-deg at (x_outer-chamfer/2, y_top-chamfer/2) -->
+  <geom class="track" pos="1.6050 0.5550 0.0025" size="0.0636 0.018 0.0025" euler="0 0 -45"/>
+  <!-- corner BR: 45-deg at (x_outer-chamfer/2, y_bot+chamfer/2) -->
+  <geom class="track" pos="1.6050 -0.5550 0.0025" size="0.0636 0.018 0.0025" euler="0 0  45"/>
+
+  <!-- ── Left loop ── -->
+  <!-- top straight: -x_outer+chamfer → -x_inner -->
+  <geom class="track" pos="-0.8550 0.6000 0.0025" size="0.7050 0.018 0.0025"/>
+  <!-- bottom straight -->
+  <geom class="track" pos="-0.8550 -0.6000 0.0025" size="0.7050 0.018 0.0025"/>
+  <!-- left side -->
+  <geom class="track" pos="-1.6500 0.0000 0.0025" size="0.018 0.5100 0.0025"/>
+  <!-- corner TL -->
+  <geom class="track" pos="-1.6050 0.5550 0.0025" size="0.0636 0.018 0.0025" euler="0 0  45"/>
+  <!-- corner BL -->
+  <geom class="track" pos="-1.6050 -0.5550 0.0025" size="0.0636 0.018 0.0025" euler="0 0 -45"/>
+
+  <!-- ── Crossing diagonals at origin ── -->
+  <!--  A: ( 0.15, -0.60) → (-0.15, 0.60)  angle=104.0deg -->
+  <!--  B: (-0.15, -0.60) → ( 0.15, 0.60)  angle=76.0deg -->
+  <geom class="track" pos="0 0 0.0025" size="0.6185 0.018 0.0025" euler="0 0 104.04"/>
+  <geom class="track" pos="0 0 0.0025" size="0.6185 0.018 0.0025" euler="0 0 75.96"/>
+
+  <!-- ── Junction connectors: diagonals meet loop straights ── -->
+  <!-- These small squares bridge the diagonal tip to the straight end -->
+  <geom class="track" pos=" 0.1500  0.6000 0.0025" size="0.018 0.018 0.0025"/>
+  <geom class="track" pos=" 0.1500  -0.6000 0.0025" size="0.018 0.018 0.0025"/>
+  <geom class="track" pos="-0.1500  0.6000 0.0025" size="0.018 0.018 0.0025"/>
+  <geom class="track" pos="-0.1500  -0.6000 0.0025" size="0.018 0.018 0.0025"/>
+
+</mujocoinclude>


### PR DESCRIPTION
This PR introduces a sensor-rich car model used in two examples: line following and platooning.

The car is equipped with 5 line sensors and 2 range finders (front and rear).

The model is designed in a modular and composable way, with the track defined in a separate model file for reuse and clarity.

- `CarLineFollow.lf` implements a PD controller for line following using the line sensors. `kp`and `kd` can be frther tuned.
- `CarPlatoon.lf` defines a platoon of three cars and applies the same control principles as the line follower.

The current platooning implementation is basic and does not yet exploit the range finders.

Next steps are extending and incorporating inter-vehicle spacing using front and rear distance measurements.